### PR TITLE
ci: use STEP_DEBUG flag on integration tests

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -61,7 +61,7 @@ jobs:
       #   env:
       #     COVERAGE: ${{ matrix.coverage }}
       #     USING_XDEBUG: ${{ matrix.coverage }}
-      #     DEBUG: ${{ matrix.debug }}
+      #     DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG || matrix.debug }}
       #     SKIP_TESTS_CLEANUP: ${{ matrix.coverage }}
       #     SUITES: functional
       #     PHP_VERSION: ${{ matrix.php }}
@@ -72,7 +72,7 @@ jobs:
         env:
           COVERAGE: ${{ matrix.coverage }}
           USING_XDEBUG: ${{ matrix.coverage }}
-          DEBUG: ${{ matrix.debug }}
+          DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG || matrix.debug }}
           SKIP_TESTS_CLEANUP: ${{ matrix.coverage }}
           PHP_VERSION: ${{ matrix.php }}
           WP_VERSION: ${{ matrix.wordpress }}

--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -38,7 +38,6 @@ modules:
             dsn: 'mysql:host=%DB_HOST%;dbname=%DB_NAME%'
             user: '%DB_USER%'
             password: '%DB_PASSWORD%'
-            populator: 'mysql -u $user -p$password -h $host $dbname < $dump'
             dump: 'tests/_data/dump.sql'
             populate: true
             cleanup: true


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
Passes the github STEP_DEBUG secret to the integration test env, to allow for verbose codeception logging.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
