### PR TITLE
fix: incorrect globals for generating <head>.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@
 - fix: Prevent duplicate OpenGraph meta tags by clearing `RankMath` hooks before fetching.
 - fix!: Rename `playerStreamContentTypee` to `playerStreamContentType`.
 - fix: Allow `OpenGraphTwitter.appCountry` to resolve to `null`.
+- fix: set object globals for head in Model constructor.
+- dev: rename `Seo::get_rest_url_param()` to `Seo::get_object_url()`
+- dev: Locally generate <head> instead using RankMath's REST route.
 - ci: Update GitHub Actions to latest versions.
 - ci: Fix Xdebug version for PHP 7.4.
 - chore: add explicit PHP 8.1 support.
 - chore: Update composer dependencies.
+- tests: Set category when testing `ContentNodeSeoQueryCept` so `articleMeta.section` returns a value.
 
 ## v0.0.7
 - fix: prevent type prefixes clashing with other AxeWP plugins.

--- a/src/Model/ContentNodeSeo.php
+++ b/src/Model/ContentNodeSeo.php
@@ -181,7 +181,7 @@ class ContentNodeSeo extends Seo {
 	 *
 	 * @throws UserError If no post permalink.
 	 */
-	protected function get_rest_url_param() : string {
+	protected function get_object_url() : string {
 		$permalink = get_permalink( $this->database_id );
 
 		if ( false === $permalink ) {

--- a/src/Model/ContentTypeSeo.php
+++ b/src/Model/ContentTypeSeo.php
@@ -80,7 +80,7 @@ class ContentTypeSeo extends Seo {
 	 *
 	 * @throws UserError If no archive URI.
 	 */
-	protected function get_rest_url_param() : string {
+	protected function get_object_url() : string {
 		$term_link = get_post_type_archive_link( $this->data->name );
 
 		if ( false === $term_link ) {

--- a/src/Model/Seo.php
+++ b/src/Model/Seo.php
@@ -94,14 +94,18 @@ abstract class Seo extends Model {
 		);
 
 		parent::__construct( $capability, $allowed_fields );
+
+		rank_math()->variables->setup();
+		// Seat up RM Globals.
+		$url = $this->get_rest_url_param();
+
+		$this->setup_post_head( $url );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	public function setup() : void {
-		rank_math()->variables->setup();
-
 		Paper::reset();
 		/** @var \RankMath\Paper\Paper $paper */
 		$paper        = Paper::get();
@@ -200,10 +204,6 @@ abstract class Seo extends Model {
 			return $this->full_head;
 		}
 
-		$url = $this->get_rest_url_param();
-
-		$this->setup_post_head( $url );
-
 		ob_start();
 		do_action( 'wp' );
 		do_action( 'rank_math/head' );
@@ -272,7 +272,6 @@ abstract class Seo extends Model {
 		remove_all_actions( 'rank_math/opengraph/facebook' );
 		remove_all_actions( 'rank_math/opengraph/twitter' );
 		remove_all_actions( 'rank_math/opengraph/slack' );
-		wp();
 
 		if ( $headless->is_home ) {
 			$GLOBALS['wp_query']->is_home = true;

--- a/src/Model/Seo.php
+++ b/src/Model/Seo.php
@@ -188,7 +188,9 @@ abstract class Seo extends Model {
 	abstract protected function get_rest_url_param() : string;
 
 	/**
-	 * Gets the head using a REST API request.
+	 * Gets all the tags that go in the <head>.
+	 *
+	 * Shims the `RankMath\Rest\Headless::get_html_head() private method to avoid a REST Call.
 	 *
 	 * @throws Error     When the REST request is invalid.
 	 * @throws UserError When REST response fails.
@@ -198,41 +200,17 @@ abstract class Seo extends Model {
 			return $this->full_head;
 		}
 
-		$url_param = $this->get_rest_url_param();
+		$url = $this->get_rest_url_param();
 
-		$rest_url = get_rest_url( null, '/rankmath/v1/getHead?url=' . $url_param );
-		$request  = \WP_REST_Request::from_url( $rest_url );
+		$this->setup_post_head( $url );
 
-		if ( false === $request ) {
-			throw new Error(
-				sprintf(
-					// translators: %s the URL for the getHead endpoint.
-					__( 'Invalid rest request from %s', 'wp-graphql-rank-math' ),
-					$rest_url
-				)
-			);
-		}
+		ob_start();
+		do_action( 'wp' );
+		do_action( 'rank_math/head' );
 
-		// Remove RM head filters.
-		remove_all_actions( 'rank_math/head' );
-		remove_all_actions( 'rank_math/json_ld' );
-		remove_all_actions( 'rank_math/opengraph/facebook' );
-		remove_all_actions( 'rank_math/opengraph/twitter' );
-		remove_all_actions( 'rank_math/opengraph/slack' );
+		$head = ob_get_clean();
 
-		$response = rest_do_request( $request );
-
-		if ( $response->is_error() ) {
-			/** @var \WP_Error $error */
-			$error = $response->as_error();
-			throw new UserError(
-				// translators: the url.
-				sprintf( __( 'The request for the URL %s could not be retrieved. Error Message: ', 'wp-graphql-rank-math' ), $url_param, $error->get_error_message() ),
-			);
-		}
-		$data = $response->get_data();
-
-		$this->full_head = ! empty( $data['head'] ) ? $data['head'] : null;
+		$this->full_head = $head ?: null;
 
 		return $this->full_head;
 	}
@@ -274,5 +252,36 @@ abstract class Seo extends Model {
 				$tags[ $prefix ][ $property ] = $value;
 			}
 		}
+	}
+
+	/**
+	 * Prepare head output for a URL.
+	 *
+	 * Shims the RankMath\Rest\Headless::setup_post_head() private method to avoid a REST call.
+	 *
+	 * @param string $url The URL.
+	 */
+	private function setup_post_head( string $url ) : void {
+		$headless = new \RankMath\Rest\Headless();
+		// Setup WordPress.
+		$_SERVER['REQUEST_URI'] = esc_url_raw( $headless->generate_request_uri( $url ) );
+		remove_all_actions( 'wp' );
+		remove_all_actions( 'parse_request' );
+		remove_all_actions( 'rank_math/head' );
+		remove_all_actions( 'rank_math/json_ld' );
+		remove_all_actions( 'rank_math/opengraph/facebook' );
+		remove_all_actions( 'rank_math/opengraph/twitter' );
+		remove_all_actions( 'rank_math/opengraph/slack' );
+		wp();
+
+		if ( $headless->is_home ) {
+			$GLOBALS['wp_query']->is_home = true;
+		}
+
+		remove_filter( 'option_rewrite_rules', [ $headless, 'fix_query_notice' ] );
+
+		// Setup Rank Math.
+		rank_math()->variables->setup();
+		new \RankMath\Frontend\Frontend();
 	}
 }

--- a/src/Model/Seo.php
+++ b/src/Model/Seo.php
@@ -97,7 +97,7 @@ abstract class Seo extends Model {
 
 		rank_math()->variables->setup();
 		// Seat up RM Globals.
-		$url = $this->get_rest_url_param();
+		$url = $this->get_object_url();
 
 		$this->setup_post_head( $url );
 	}
@@ -187,9 +187,19 @@ abstract class Seo extends Model {
 	}
 
 	/**
-	 * Gets the object-specific url to use for the REST API RankMath url param.
+	 * Gets the object-specific url to use for generating the RankMath <head>.
 	 */
-	abstract protected function get_rest_url_param() : string;
+	abstract protected function get_object_url() : string;
+
+	/**
+	 * Gets the object-specific url to use for generating the RankMath <head>.
+	 *
+	 * @deprecated @todo
+	 */
+	protected function get_rest_url_param() : string {
+		_deprecated_function( __FUNCTION__, '@todo', __NAMESPACE__ . '::get_object_url()' );
+		return $this->get_object_url();
+	}
 
 	/**
 	 * Gets all the tags that go in the <head>.

--- a/src/Model/TermNodeSeo.php
+++ b/src/Model/TermNodeSeo.php
@@ -130,7 +130,7 @@ class TermNodeSeo extends Seo {
 	 *
 	 * @throws UserError If no valid term link.
 	 */
-	protected function get_rest_url_param() : string {
+	protected function get_object_url() : string {
 		$term_link = get_term_link( $this->database_id );
 
 		if ( is_wp_error( $term_link ) ) {

--- a/src/Model/UserSeo.php
+++ b/src/Model/UserSeo.php
@@ -120,7 +120,7 @@ class UserSeo extends Seo {
 	 *
 	 * @throws UserError If no valid term link.
 	 */
-	protected function get_rest_url_param() : string {
+	protected function get_object_url() : string {
 		$author_url = get_author_posts_url( $this->database_id );
 		return $author_url;
 	}

--- a/tests/functional/ContentNodeSeoQueryCept.php
+++ b/tests/functional/ContentNodeSeoQueryCept.php
@@ -3,13 +3,28 @@
 $I = new FunctionalTester( $scenario );
 $I->wantTo( 'Query content node seo data' );
 
+// Create post category
+$cat_id = $I->haveTermInDatabase(
+	'Category',
+	'category',
+	[
+		'description' => 'Category description',
+		'name'        => 'Test Term',
+	]
+);
+
 $post_id = $I->havePostInDatabase(
 	[
-		'post_title'   => 'Test Post',
-		'post_type'    => 'post',
-		'post_status'  => 'publish',
-		'post_content' => 'Post Content',
-	] 
+		'post_title'    => 'Test Post',
+		'post_type'     => 'post',
+		'post_status'   => 'publish',
+		'post_content'  => 'Post Content',
+		'tax_input'   => [
+			'category' => [
+				$cat_id[0],
+			],
+		],
+	]
 );
 
 // Enable Headless support and breadcrumbs in rank math general

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'axepress/wp-graphql-rank-math',
         'pretty_version' => 'dev-develop',
         'version' => 'dev-develop',
-        'reference' => '8a439acf32f337ea039e4b3fce55682b5dd129ef',
+        'reference' => '81228cf90b47b7fd5b56c0235d5a51e1f2aeb2ee',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -22,7 +22,7 @@
         'axepress/wp-graphql-rank-math' => array(
             'pretty_version' => 'dev-develop',
             'version' => 'dev-develop',
-            'reference' => '8a439acf32f337ea039e4b3fce55682b5dd129ef',
+            'reference' => '81228cf90b47b7fd5b56c0235d5a51e1f2aeb2ee',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
This PR fixes several issues where the wrong WP globals were used to generate the RankMath `<head>` metadata and associated fields (like OpenGraph).

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
The issue manifested itself in several ways:
- When querying for a `listOf` objects, the first object would still be used to determine the `Paper()` class.
- When querying for a connected object type, the parent object would still be used to determine the `Paper()` class.
- When using a nonstandard WP Site URL (e.g `frontend.test.test` ), the REST API would automatically convert the url front to the backend (e.g. `backend.test.test/my-post` ), causing an error to be thrown when fetching the `fullHead`.

closes #19 

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->
TL;DR instead of using RM's REST route to fetch the head, we're shimming the methods and generating it locally instead.

- fix: set object globals for head in Model constructor.
- dev: rename `Seo::get_rest_url_param()` to `Seo::get_object_url()`
- dev: Locally generate <head> instead using RankMath's REST route.
- tests: Set category when testing `ContentNodeSeoQueryCept` so `articleMeta.section` returns a value.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
