### PR TITLE
fix: pass necessary data to resolve OpenGraphMeta.image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- fix: pass necessary data to resolve `OpenGraphMeta.image` field.
+
 ## v0.0.10
 - dev: check plugin dependency versions.
 - dev: namespace Composer dependencies with Strauss.

--- a/src/Type/WPObject/OpenGraphMeta.php
+++ b/src/Type/WPObject/OpenGraphMeta.php
@@ -70,7 +70,21 @@ class OpenGraphMeta extends ObjectType {
 			'image'             => [
 				'type'        => OpenGraph\Image::get_type_name(),
 				'description' => __( 'The OpenGraph image meta', 'wp-graphql-rank-math' ),
-				'resolve'     => fn( $source ) : ?array => ! empty( $source['og']['image'] ) ? $source['og']['image'] : null,
+				'resolve'     => function( $source ) : ?array {
+					$values = [];
+
+					// The URL is stored in it's own key.
+					if ( ! empty( $source['og']['image'] ) ) {
+						$values['url'] = $source['og']['image'];
+					}
+
+					// The rest of the data is stored in an array.
+					if ( ! empty( $source['og:image'] ) ) {
+						$values = array_merge( $values, $source['og:image'] );
+					}
+
+					return ! empty( $values ) ? $values : null;
+				},
 			],
 			'facebookMeta'      => [
 				'type'        => OpenGraph\Facebook::get_type_name(),


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
This PR fixes the resolver used for `OpenGraphMeta.image` to correctly return the data needed to populate the `OpenGraphImage` type.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

Rank Math stores the `url` in `$og['image']` and all the other properties in `$og['og:image']` 🤷‍♂️

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->
- fix: pass necessary data to resolve `OpenGraphMeta.image` field.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
