### PR TITLE
fix: Use correct post type when querying for `ContentNodeSeo` on revisions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- fix: Use correct post type when querying for `ContentNodeSeo` on revisions. Props @idflood
 - chore: Update Strauss and Composer dev-dependencies to latest versions.
 
 ## v0.0.11

--- a/src/Model/ContentNodeSeo.php
+++ b/src/Model/ContentNodeSeo.php
@@ -181,12 +181,15 @@ class ContentNodeSeo extends Seo {
 	 * {@inheritDoc}
 	 */
 	public function get_object_type() : string {
-		$post_types = WPGraphQL::get_allowed_post_types( 'objects' );
-		$post_type = $this->data->post_type;
-		if ( 'revision' === $post_type ) {
-			$post_type = get_post_type($this->data->post_parent);
+		$post_types        = WPGraphQL::get_allowed_post_types( 'objects' );
+		$current_post_type = $this->data->post_type;
+
+		// If this is a revision, get the post type of the parent.
+		if ( 'revision' === $current_post_type ) {
+			$current_post_type = get_post_type( $this->data->post_parent );
 		}
-		return $post_types[ $post_type ]->graphql_single_name;
+
+		return $post_types[ $current_post_type ]->graphql_single_name;
 	}
 
 	/**

--- a/src/Model/ContentNodeSeo.php
+++ b/src/Model/ContentNodeSeo.php
@@ -182,8 +182,11 @@ class ContentNodeSeo extends Seo {
 	 */
 	public function get_object_type() : string {
 		$post_types = WPGraphQL::get_allowed_post_types( 'objects' );
-
-		return $post_types[ $this->data->post_type ]->graphql_single_name;
+		$post_type = $this->data->post_type;
+		if ($post_type == 'revision') {
+			$post_type = get_post_type($this->data->post_parent);
+		}
+		return $post_types[ $post_type ]->graphql_single_name;
 	}
 
 	/**

--- a/src/Model/ContentNodeSeo.php
+++ b/src/Model/ContentNodeSeo.php
@@ -183,7 +183,7 @@ class ContentNodeSeo extends Seo {
 	public function get_object_type() : string {
 		$post_types = WPGraphQL::get_allowed_post_types( 'objects' );
 		$post_type = $this->data->post_type;
-		if ($post_type == 'revision') {
+		if ( 'revision' === $post_type ) {
 			$post_type = get_post_type($this->data->post_parent);
 		}
 		return $post_types[ $post_type ]->graphql_single_name;

--- a/tests/wpunit/ContentNodeSeoQueryTest.php
+++ b/tests/wpunit/ContentNodeSeoQueryTest.php
@@ -92,7 +92,6 @@ class ContentNodeSeoQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 				$this->expectedObject(
 					'contentNode',
 					[
-						$this->expectedField( 'databaseId', $this->database_id ),
 						$this->expectedObject(
 							'seo',
 							[
@@ -152,6 +151,8 @@ class ContentNodeSeoQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
+		$this->assertEquals( $this->database_id, $actual['data']['contentNode']['databaseId'] );
+
 		$this->assertValidSeo( $actual );
 
 		// Test individual values:
@@ -163,10 +164,22 @@ class ContentNodeSeoQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 	 * Tests seo on the contentNode preview.
 	 */
 	public function testContentNodeSeoAsPreview() {
+		// Test revision on existing post.
+		wp_set_current_user( $this->admin );
+		$revision_id = $this->factory()->post->create(
+			[
+				'post_type'   => 'revision',
+				'post_status' => 'inherit',
+				'post_title'  => 'Post Title',
+				'post_author' => $this->admin,
+				'post_parent' => $this->database_id,
+			]
+		);
+
 		$query = $this->get_query();
 
 		$variables = [
-			'id'        => $this->database_id,
+			'id'        => $revision_id,
 			'idType'    => 'DATABASE_ID',
 			'asPreview' => true,
 		];
@@ -174,10 +187,86 @@ class ContentNodeSeoQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 		$actual = $this->graphql( compact( 'query', 'variables' ) );
 		$this->assertArrayNotHasKey( 'errors', $actual );
 
+		$this->assertEquals( $revision_id, $actual['data']['contentNode']['databaseId'] );
+
 		$this->assertValidSeo( $actual );
 
-		// Test individual values:
-		$this->assertStringContainsString( home_url(), $actual['data']['contentNode']['seo']['canonicalUrl'] );
-		$this->assertStringContainsString( '<script type="application/ld+json" class="rank-math-schema">', $actual['data']['contentNode']['seo']['jsonLd']['raw'] );
+		// Test revision on draft.
+		$draft_id = $this->factory()->post->create(
+			[
+				'post_type'   => $this->with_post_type,
+				'post_status' => 'draft',
+				'post_title'  => 'Draft Title',
+				'post_author' => $this->admin,
+			]
+		);
+
+		$revision_id = $this->factory()->post->create(
+			[
+				'post_type'   => 'revision',
+				'post_status' => 'inherit',
+				'post_title'  => 'Draft Title',
+				'post_author' => $this->admin,
+				'post_parent' => $draft_id,
+			]
+		);
+
+		$variables = [
+			'id'        => $revision_id,
+			'idType'    => 'DATABASE_ID',
+			'asPreview' => true,
+		];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayNotHasKey( 'errors', $actual );
+
+		$this->assertQuerySuccessful(
+			$actual,
+			[
+				$this->expectedObject(
+					'contentNode',
+					[
+						$this->expectedObject(
+							'seo',
+							[
+								$this->expectedNode(
+									'breadcrumbs',
+									[
+										$this->expectedField( 'text', 'Draft Title' ),
+										$this->expectedField( 'url', get_permalink( $draft_id ) ),
+										$this->expectedField( 'isHidden', false ),
+									],
+									2
+								),
+								$this->expectedField( 'breadcrumbTitle', 'Draft Title' ),
+								$this->expectedField( 'description', get_the_excerpt( $draft_id ) ),
+								$this->expectedField( 'focusKeywords', static::IS_NULL ),
+								$this->expectedField( 'isPillarContent', false ),
+								$this->expectedField(
+									'robots',
+									[
+										'index',
+										'follow',
+										'max-snippet:-1',
+										'max-video-preview:-1',
+										'max-image-preview:large',
+									]
+								),
+								$this->expectedField( 'title', 'Draft Title - Test' ),
+								$this->expectedObject(
+									'seoScore',
+									[
+										$this->expectedField( 'badgeHtml', static::IS_NULL ),
+										$this->expectedField( 'hasFrontendScore', false ),
+										$this->expectedField( 'rating', 'UNKNOWN' ),
+										$this->expectedField( 'score', 0 ),
+									]
+								),
+							]
+						),
+					]
+				),
+			]
+		);
 	}
 }


### PR DESCRIPTION
Implement fix for get_object_type() when object is a revision.


## What
The function `get_object_type` returned null when using `asPreview` parameter. 

## Why
When using `asPreview`, the content type is `revision` and doesn't match the allowed types.

## How
This pull request check if `$this->data->post_type` is a revision, and if this is the case it returns the parent post type.

## Testing Instructions
You can try a query like this while being connected.

```

{
  contentNode(id: "2011", idType: DATABASE_ID, asPreview: true) {
    ... on Page {
      title

      seo {
          description
      }
    }
  }
}
```

The graphql error happen after adding asPreview parameter.

## Checklist:
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards.
- [x] My code has proper inline documentation.
- [x] I have added unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
