### PR TITLE
dev: show conflict notice for wp-graphql-yoast-seo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - fix: Use correct post type when querying for `ContentNodeSeo` on revisions. Props @idflood
+- dev: Show admin notice when conflicting `wp-graphql-yoast-seo` is installed.
 - chore: Update Strauss and Composer dev-dependencies to latest versions.
 - ci: Test plugin compatibility with WordPress 6.2
 

--- a/wp-graphql-rank-math.php
+++ b/wp-graphql-rank-math.php
@@ -113,7 +113,7 @@ if ( ! function_exists( 'graphql_seo_plugin_conflicts' ) ) {
 		$conflicts = [];
 
 		if ( function_exists( 'wp_gql_seo_build_content_type_data' ) ) {
-			$conflicts['WPGraphQL Yoast SEO Addon'] = __( 'Please delete the plugin entirely (sometimes listed as "Add WPGraphQL SEO", located in `path/to/wp-content/plugins/wp-graphql-yoast-seo`) before continuing.', 'wp-graphql-rank-math' );
+			$conflicts['WPGraphQL Yoast SEO Addon'] = __( 'This plugin may appear as "Add WPGraphQL SEO" in the plugin list.', 'wp-graphql-rank-math' );
 		}
 
 		return $conflicts;
@@ -163,20 +163,28 @@ if ( ! function_exists( 'graphql_seo_init' ) ) {
 		}
 
 		// Output an error notice for the conflicting plugins.
-		foreach ( $conflicts as $conflict => $resolution ) {
+		foreach ( $conflicts as $conflict => $note ) {
 			add_action(
 				'admin_notices',
-				static function () use ( $conflict, $resolution ) {
+				static function () use ( $conflict, $note ) {
 					?>
 				<div class="error notice">
 					<p>
 						<?php
 						printf(
 							/* translators: dependency not ready error message */
-							esc_html__( '%1$s is not compatible with WPGraphQL for Rank Math SEO. %2$s', 'wp-graphql-rank-math' ),
+							esc_html__( '%1$s is not compatible with WPGraphQL for Rank Math SEO. Please deactivate it.', 'wp-graphql-rank-math' ),
 							esc_attr( $conflict ),
-							$resolution ?: esc_html__( 'Please deactivate it.', 'wp-graphql-rank-math' )
 						);
+
+						if ( ! empty( $note ) ) {
+							// translators: resolution message.
+							printf(
+								'<br /><em>%1$s</em> %2$s',
+								esc_html__( 'Note: ', 'wp-graphql-rank-math' ),
+								esc_html( $note ),
+							);
+						}
 						?>
 					</p>
 				</div>

--- a/wp-graphql-rank-math.php
+++ b/wp-graphql-rank-math.php
@@ -103,6 +103,23 @@ if ( ! function_exists( 'graphql_seo_dependencies_not_ready' ) ) {
 	}
 }
 
+if ( ! function_exists( 'graphql_seo_plugin_conflicts' ) ) {
+	/**
+	 * Checks if any known plugin conflicts are present.
+	 *
+	 * @since @todo
+	 */
+	function graphql_seo_plugin_conflicts() : array {
+		$conflicts = [];
+
+		if ( function_exists( 'wp_gql_seo_build_content_type_data' ) ) {
+			$conflicts['WPGraphQL Yoast SEO Addon'] = __( 'Please delete the plugin entirely (sometimes listed as "Add WPGraphQL SEO", located in `path/to/wp-content/plugins/wp-graphql-yoast-seo`) before continuing.', 'wp-graphql-rank-math' );
+		}
+
+		return $conflicts;
+	}
+}
+
 if ( ! function_exists( 'graphql_seo_init' ) ) {
 
 	/**
@@ -113,12 +130,16 @@ if ( ! function_exists( 'graphql_seo_init' ) ) {
 
 		$not_ready = graphql_seo_dependencies_not_ready();
 
-		if ( empty( $not_ready ) && defined( 'WPGRAPHQL_SEO_PLUGIN_DIR' ) ) {
+		// Get the conflicting plugins.
+		$conflicts = graphql_seo_plugin_conflicts();
+
+		if ( empty( $not_ready ) && empty( $conflicts ) && defined( 'WPGRAPHQL_SEO_PLUGIN_DIR' ) ) {
 			require_once WPGRAPHQL_SEO_PLUGIN_DIR . 'src/Main.php';
 			\WPGraphQL\RankMath\Main::instance();
 			return;
 		}
 
+		// Output an error notice for the dependencies that are not ready.
 		foreach ( $not_ready as $dep => $version ) {
 			add_action(
 				'admin_notices',
@@ -136,6 +157,29 @@ if ( ! function_exists( 'graphql_seo_init' ) ) {
 							?>
 						</p>
 					</div>
+					<?php
+				}
+			);
+		}
+
+		// Output an error notice for the conflicting plugins.
+		foreach ( $conflicts as $conflict => $resolution ) {
+			add_action(
+				'admin_notices',
+				static function () use ( $conflict, $resolution ) {
+					?>
+				<div class="error notice">
+					<p>
+						<?php
+						printf(
+							/* translators: dependency not ready error message */
+							esc_html__( '%1$s is not compatible with WPGraphQL for Rank Math SEO. %2$s', 'wp-graphql-rank-math' ),
+							esc_attr( $conflict ),
+							$resolution ?: esc_html__( 'Please deactivate it.', 'wp-graphql-rank-math' )
+						);
+						?>
+					</p>
+				</div>
 					<?php
 				}
 			);


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

Shows a conflict notice if `wp-graphql-yoast-seo` is installed.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Closes #42.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

It checks for the `wp_gql_seo_build_content_type_data()` function since wp-graphql-yoast-seo doesn't use classes or namespaces 🤷

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Install `wp-graphql-yoast-seo` (sometimes listed as "Add WPGraphQL SEO" or "WPGraphQL Yoast SEO Addon")
2. Confirm notice on plugins screen.

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->
![image](https://github.com/AxeWP/wp-graphql-rank-math/assets/29322304/bd59da90-9366-466d-8616-ef3a64afa837)

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
