### PR TITLE
dev: decode HTML entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - feat: Expose Redirections to the GraphQL schema.
+- dev: Convert HTML entities for `breadcrumbTitle`, `description`, and `title` fields to their corresponding characters. H/t @sdegetaus
 - chore: Implement `axepress/wp-graphql-cs` ruleset for PHP_CodeSniffer.
 
 ## v0.0.12

--- a/src/Model/ContentNodeSeo.php
+++ b/src/Model/ContentNodeSeo.php
@@ -155,7 +155,11 @@ class ContentNodeSeo extends Seo {
 			$this->fields = array_merge(
 				$this->fields,
 				[
-					'breadcrumbTitle' => fn (): ?string => $this->get_meta( 'breadcrumb_title', '', get_the_title( $this->database_id ) ) ?: null,
+					'breadcrumbTitle' => function (): ?string {
+						$title = $this->get_meta( 'breadcrumb_title', '', get_the_title( $this->database_id ) );
+
+						return ! empty( $title ) ? html_entity_decode( $title, ENT_QUOTES ) : null;
+					},
 					'isPillarContent' => fn (): bool => ! empty( $this->get_meta( 'pillar_content' ) ),
 					'seoScore'        => fn () => [
 						'hasFrontendScore' => static fn (): bool => rank_math()->frontend_seo_score->score_enabled(),

--- a/src/Model/Seo.php
+++ b/src/Model/Seo.php
@@ -120,10 +120,14 @@ abstract class Seo extends Model {
 		if ( empty( $this->fields ) ) {
 			$this->fields = [
 				'title'         => function (): ?string {
-					return $this->helper->get_title() ?: null;
+					$title = $this->helper->get_title();
+
+					return ! empty( $title ) ? html_entity_decode( $title, ENT_QUOTES ) : null;
 				},
 				'description'   => function (): ?string {
-					return $this->helper->get_description() ?: null;
+					$description = $this->helper->get_description();
+
+					return ! empty( $description ) ? html_entity_decode( $description, ENT_QUOTES ) : null;
 				},
 				'robots'        => function (): ?array {
 					return $this->helper->get_robots() ?: null;

--- a/src/Model/TermNodeSeo.php
+++ b/src/Model/TermNodeSeo.php
@@ -118,8 +118,11 @@ class TermNodeSeo extends Seo {
 			$this->fields = array_merge(
 				$this->fields,
 				[
-					'breadcrumbTitle' => fn (): ?string => $this->get_meta( 'breadcrumb_title', '', $this->data->name ) ?: null,
+					'breadcrumbTitle' => function (): ?string {
+						$title = $this->get_meta( 'breadcrumb_title', '', $this->data->name );
 
+						return ! empty( $title ) ? html_entity_decode( $title, ENT_QUOTES ) : null;
+					},
 				]
 			);
 		}

--- a/src/Model/UserSeo.php
+++ b/src/Model/UserSeo.php
@@ -106,7 +106,11 @@ class UserSeo extends Seo {
 			$this->fields = array_merge(
 				$this->fields,
 				[
-					'breadcrumbTitle' => fn (): ?string => $this->get_meta( 'breadcrumb_title', '', $this->data->display_name ) ?: null,
+					'breadcrumbTitle' => function (): ?string {
+						$title = $this->get_meta( 'breadcrumb_title', '', $this->data->display_name );
+
+						return ! empty( $title ) ? html_entity_decode( $title, ENT_QUOTES ) : null;
+					},
 					'ID'              => fn (): int => $this->database_id,
 				]
 			);


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR passes the `seo.title`, `.description`, and `.breadcrumbTitle` via `html_entities_decode()` when populating the respective WPGraphQL models.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Closes #50 

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
