### PR TITLE
Return expected data when querying seo data of custom taxonomy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## Unreleased
-- fix: Return expected seo data when querying custom taxonomy
+- fix: Fetch the correct SEO data when resolving custom taxonomy terms. Props @lucguerraz
+- dev!: Move `SEO::$global_authordata` property to the `UserSeo` model and make nullable.
+- dev: Move `seo.breadcrumbs` resolution from the `RankMathSeo` interface to the `SEO` model.
 
 ## v0.0.13
 - feat: Expose Redirections to the GraphQL schema.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- fix: Return expected seo data when querying custom taxonomy
 
 ## v0.0.13
 - feat: Expose Redirections to the GraphQL schema.

--- a/src/Model/Seo.php
+++ b/src/Model/Seo.php
@@ -297,6 +297,7 @@ abstract class Seo extends Model {
 		remove_all_actions( 'rank_math/opengraph/facebook' );
 		remove_all_actions( 'rank_math/opengraph/twitter' );
 		remove_all_actions( 'rank_math/opengraph/slack' );
+		wp();
 
 		if ( $headless->is_home ) {
 			$GLOBALS['wp_query']->is_home = true;

--- a/src/Model/Seo.php
+++ b/src/Model/Seo.php
@@ -297,7 +297,6 @@ abstract class Seo extends Model {
 		remove_all_actions( 'rank_math/opengraph/facebook' );
 		remove_all_actions( 'rank_math/opengraph/twitter' );
 		remove_all_actions( 'rank_math/opengraph/slack' );
-		wp();
 
 		if ( $headless->is_home ) {
 			$GLOBALS['wp_query']->is_home = true;

--- a/src/Model/UserSeo.php
+++ b/src/Model/UserSeo.php
@@ -25,7 +25,7 @@ class UserSeo extends Seo {
 	/**
 	 * The global authordata at time of Model generation
 	 *
-	 * @var \WP_User
+	 * @var ?\WP_User
 	 */
 	protected $global_authordata;
 
@@ -84,7 +84,7 @@ class UserSeo extends Seo {
 			// Setup globals.
 			$wp_query->is_author         = true;
 			$GLOBALS['authordata']       = $this->data; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
-			$author = $this->data->ID;
+			$author                      = $this->data->ID; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound,SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 			$wp_query->queried_object    = $this->data;
 			$wp_query->queried_object_id = $this->data->ID;
 		}
@@ -99,8 +99,13 @@ class UserSeo extends Seo {
 	 * @return void
 	 */
 	public function tear_down() {
-		$GLOBALS['authordata'] = $this->global_authordata; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
-		$GLOBALS['post']       = $this->global_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
+		global $author;
+		if ( $this->data instanceof \WP_User ) {
+			$author                = isset( $this->global_authordata ) ? $this->global_authordata->ID : null; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
+			$GLOBALS['authordata'] = $this->global_authordata; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
+			$GLOBALS['post']       = $this->global_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
+		}
+
 		wp_reset_postdata();
 	}
 

--- a/src/Model/UserSeo.php
+++ b/src/Model/UserSeo.php
@@ -23,6 +23,13 @@ class UserSeo extends Seo {
 	protected $data;
 
 	/**
+	 * The global authordata at time of Model generation
+	 *
+	 * @var \WP_User
+	 */
+	protected $global_authordata;
+
+	/**
 	 * The settings prefix
 	 *
 	 * @var string
@@ -56,7 +63,7 @@ class UserSeo extends Seo {
 	 * {@inheritDoc}
 	 */
 	public function setup(): void {
-		global $wp_query, $post, $authordata;
+		global $wp_query, $post, $author, $authordata;
 
 		// Store variables for resetting at tear down.
 		$this->global_post       = $post;
@@ -77,7 +84,8 @@ class UserSeo extends Seo {
 			// Setup globals.
 			$wp_query->is_author         = true;
 			$GLOBALS['authordata']       = $this->data; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
-			$wp_query->queried_object    = get_user_by( 'id', $this->data->ID );
+			$author = $this->data->ID;
+			$wp_query->queried_object    = $this->data;
 			$wp_query->queried_object_id = $this->data->ID;
 		}
 

--- a/src/Type/WPInterface/Seo.php
+++ b/src/Type/WPInterface/Seo.php
@@ -8,7 +8,6 @@
 
 namespace WPGraphQL\RankMath\Type\WPInterface;
 
-use RankMath\Frontend\Breadcrumbs as RMBreadcrumbs;
 use RankMath\Helper;
 use WPGraphQL\RankMath\Model\ContentNodeSeo;
 use WPGraphQL\RankMath\Model\ContentTypeSeo;
@@ -89,36 +88,6 @@ class Seo extends InterfaceType {
 			$fields['breadcrumbs'] = [
 				'type'        => [ 'list_of' => Breadcrumbs::get_type_name() ],
 				'description' => __( 'The breadcrumbs trail for the given object', 'wp-graphql-rank-math' ),
-				'resolve'     => static function ( $source ) {
-					if ( $source instanceof UserSeo ) {
-						// RankMath uses the global $author for generating crumbs.
-						global $author;
-
-						// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
-						$author = $source->ID;
-					}
-
-					// Get the crumbs and shape them.
-					$crumbs      = RMBreadcrumbs::get()->get_crumbs();
-					$breadcrumbs = array_map(
-						static function ( $crumb ) {
-							return [
-								'text'     => $crumb[0] ?? null,
-								'url'      => $crumb[1] ?? null,
-								'isHidden' => ! empty( $crumb['hide_in_schema'] ),
-							];
-						},
-						$crumbs
-					);
-
-					// Pop the current item's title.
-					$remove_title = ( is_single( $source->database_id ) || is_page( $source->database_id ) ) && Helper::get_settings( 'general.breadcrumbs_remove_post_title' );
-					if ( $remove_title ) {
-						array_pop( $breadcrumbs );
-					}
-
-					return ! empty( $breadcrumbs ) ? $breadcrumbs : null;
-				},
 			];
 		}
 

--- a/tests/wpunit/CPTQueryTest.php
+++ b/tests/wpunit/CPTQueryTest.php
@@ -1,0 +1,175 @@
+<?php
+
+
+/**
+ * Tests Custom Post Types and Taxonomy Term seo queries.
+ */
+class CPTQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
+	public $admin;
+	public $term_id;
+	public $post_id;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Changing the permalink structure requires the taxonomies to be reregistered.
+		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
+		register_post_type(
+			'test_custom_tax_cpt',
+			[
+				'show_in_graphql'     => true,
+				'graphql_single_name' => 'customTaxCpt',
+				'graphql_plural_name' => 'customTaxCpts',
+				'hierarchical'        => true,
+				'taxonomies'          => [ 'test_custom_tax' ],
+			]
+		);
+		register_taxonomy(
+			'test_custom_tax',
+			[ 'test_custom_tax_cpt' ],
+			[
+				'show_in_graphql'     => true,
+				'graphql_single_name' => 'customTaxTerm',
+				'graphql_plural_name' => 'customTaxTerms',
+				'hierarchical'        => true,
+			]
+		);
+
+		// Set Rank Math Settings
+		rank_math()->settings->set( 'general', 'breadcrumbs', true );
+		rank_math()->settings->set( 'general', 'headless_support', true );
+		rank_math()->settings->set( 'titles', 'tax_test_custom_tax_description', '%term_description%' );
+		rank_math()->settings->set( 'titles', 'tax_test_custom_tax_title', ' %term% %sep% %sitename%' );
+
+		// Create data
+		$this->admin = $this->factory()->user->create(
+			[
+				'role' => 'administrator',
+			]
+		);
+
+		$this->term_id = $this->factory()->term->create(
+			[
+				'taxonomy'    => 'test_custom_tax',
+				'name'        => 'Test term',
+				'description' => 'Test term description',
+			]
+		);
+
+		$this->post_id = $this->factory()->post->create(
+			[
+				'post_title'  => 'Test post',
+				'post_type'   => 'test_custom_tax_cpt',
+				'post_status' => 'publish',
+				'tax_input'   => [
+					'test_custom_tax' => [
+						$this->term_id,
+					],
+				],
+			]
+		);
+
+		$this->clearSchema();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function tearDown(): void {
+		rank_math()->settings->set( 'general', 'breadcrumbs', false );
+		wp_delete_post( $this->post_id, true );
+		wp_delete_term( $this->term_id, 'test_custom_tax', true );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests seo as term node.
+	 */
+	public function testTermNodeSeo() {
+		wp_set_current_user( $this->admin );
+
+		$query = '
+			query TermNodeSeo( $id: ID! ) {
+				termNode( id: $id, idType: DATABASE_ID ){ 
+					seo {
+						breadcrumbs {
+							text
+							url
+							isHidden
+						}
+						breadcrumbTitle
+						canonicalUrl
+						description
+						focusKeywords
+						jsonLd {
+							raw
+						}
+						robots
+						title
+						openGraph {
+							alternateLocales
+							description
+							locale
+							siteName
+							title
+							type
+							url
+							
+							
+							
+						}
+					}
+				}
+			}
+		';
+
+		$variables = [ 'id' => $this->term_id ];
+
+		$actual = $this->graphql( compact( 'query', 'variables' ) );
+
+		$this->assertQuerySuccessful(
+			$actual,
+			[
+				$this->expectedObject(
+					'termNode',
+					[
+						$this->expectedObject(
+							'seo',
+							[
+								$this->expectedNode(
+									'breadcrumbs',
+									[
+										$this->expectedField( 'text', 'Test term' ),
+										$this->expectedField( 'url', get_term_link( $this->term_id ) ),
+										$this->expectedField( 'isHidden', false ),
+									],
+									2
+								),
+								$this->expectedField( 'breadcrumbTitle', 'Test term' ),
+								$this->expectedField( 'description', 'Test term description' ),
+								$this->expectedField( 'focusKeywords', self::IS_NULL ),
+								$this->expectedField(
+									'robots',
+									[
+										'follow',
+										'noindex',
+									]
+								),
+								$this->expectedField( 'title', 'Test term - Test' ),
+							]
+						),
+					]
+				),
+			]
+		);
+
+		// Test individual values:
+		$this->assertStringContainsString( home_url(), $actual['data']['termNode']['seo']['canonicalUrl'] );
+
+		$this->assertStringContainsString( '<script type="application/ld+json" class="rank-math-schema">', $actual['data']['termNode']['seo']['jsonLd']['raw'] );
+	}
+}

--- a/tests/wpunit/ContentTypeSeoQueryTest.php
+++ b/tests/wpunit/ContentTypeSeoQueryTest.php
@@ -1,13 +1,10 @@
 <?php
 
-use WPGraphQL\RankMath\Type\Enum\OpenGraphLocaleEnum;
-use WPGraphQL\RankMath\Type\Enum\TwitterCardTypeEnum;
 
 /**
  * Tests ContentType seo queries.
  */
 class ContentTypeSeoQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
-
 	public $admin;
 	public $tester;
 
@@ -45,6 +42,17 @@ class ContentTypeSeoQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 		WPGraphQL::clear_schema();
 	}
 
+		/**
+		 * {@inheritDoc}
+		 */
+	public function tearDown(): void {
+		rank_math()->settings->set( 'general', 'breadcrumbs', false );
+
+		parent::tearDown();
+
+		$this->clearSchema();
+	}
+
 	/**
 	 * Tests rankMathSettings.general
 	 */
@@ -79,9 +87,9 @@ class ContentTypeSeoQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCas
 							'seo',
 							[
 								$this->expectedField( 'breadcrumbTitle', 'Post' ),
-								$this->expectedField( 'canonicalUrl', static::IS_NULL ),
+								$this->expectedField( 'canonicalUrl', self::IS_NULL ),
 								$this->expectedField( 'description', 'Just another WordPress site' ),
-								$this->expectedField( 'focusKeywords', static::IS_NULL ),
+								$this->expectedField( 'focusKeywords', self::IS_NULL ),
 								$this->expectedField(
 									'robots',
 									[


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
When querying a custom taxonomy the seo data is wrong or is null. Expected behaviour would be for it to return the data set in the taxonomy

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
When querying a custom taxonomy to be able to display a taxonomy archive with a query such as this one:
```
query ExampleQuery {
  exampletax(id: "example-tax-1", idType: SLUG) {
    id
    name
    slug
    examplecpts {
      nodes {
        title
        slug
      }
    }
    seo {
      title
      robots
      description
      canonicalUrl
      openGraph {
        locale
        type
        title
        description
        url
        siteName
        updatedTime
        image {
          url
          width
          height
          type
        }
        twitterMeta {
          card
          title
          image
        }
      }
    }
  }
}
```
the returned data is either wrong or null, such as this:
```
{
  "data": {
    "exampletax": {
      "id": "dGVybToy",
      "name": "Example Tax #1",
      "slug": "example-tax-1",
      "examplecpts": {
        "nodes": [
          {
            "title": "Example Post #2",
            "slug": "example-post-2"
          },
          {
            "title": "Example Post #1",
            "slug": "example-post-1"
          }
        ]
      },
      "seo": {
        "title": null,
        "robots": [
          "follow",
          "index"
        ],
        "description": null,
        "canonicalUrl": null,
        "openGraph": {
          "locale": "EN_US",
          "type": "article",
          "title": null,
          "description": null,
          "url": null,
          "siteName": "RankMath GraphQL Example",
          "updatedTime": null,
          "image": null,
          "twitterMeta": {
            "card": "SUMMARY_LARGE_IMAGE",
            "title": null,
            "image": null
          }
        }
      }
    }
  }
}
```
After applying my proposed fix the returned data is as expected:
```
{
  "data": {
    "exampletax": {
      "id": "dGVybToy",
      "name": "Example Tax #1",
      "slug": "example-tax-1",
      "examplecpts": {
        "nodes": [
          {
            "title": "Example Post #2",
            "slug": "example-post-2"
          },
          {
            "title": "Example Post #1",
            "slug": "example-post-1"
          }
        ]
      },
      "seo": {
        "title": "Example Tax #1 Archives - RankMath GraphQL Example",
        "robots": [
          "follow",
          "index",
          "max-snippet:-1",
          "max-video-preview:-1",
          "max-image-preview:large"
        ],
        "description": null,
        "canonicalUrl": "http://localhost:8888/exampletax/example-tax-1/",
        "openGraph": {
          "locale": "EN_US",
          "type": "article",
          "title": "Example Tax #1 Archives - RankMath GraphQL Example",
          "description": "This is a short description for the Example Tax #1",
          "url": "http://localhost:8888/exampletax/example-tax-1/",
          "siteName": "RankMath GraphQL Example",
          "updatedTime": null,
          "image": null,
          "twitterMeta": {
            "card": "SUMMARY_LARGE_IMAGE",
            "title": "Example Tax #1 Archives - RankMath GraphQL Example",
            "image": null
          }
        }
      }
    }
  }
}
```

## How
By adding a `wp()` function call to the `setup_post_head` method of the `Model\Seo` class this resolves the problem. The inline comment of this method mentions this being a shim of an internal RankMath method, the RankMath method calls this `wp()` function to complete it's job. After trying it, I discovered that this resolved the problem without any observable ill effects.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Create a custom Post type and a custom taxonomy, query the custom taxonomy archive to get the seo data

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [ ] I have added unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md 
