### PR TITLE
chore: test against WP 6.3

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -22,12 +22,14 @@ jobs:
     strategy:
       matrix:
         php: ["7.4", "8.0", "8.1"]
-        wordpress: ["6.2", "6.1", "6.0", "5.9"]
+        wordpress: ["6.3", "6.2", "6.1", "6.0", "5.9"]
         include:
           - php: "8.1"
-            wordpress: "6.2"
+            wordpress: "6.3"
             coverage: 1
         exclude:
+          - php: "7.4"
+            wordpress: "6.3"
           - php: "7.4"
             wordpress: "6.2"
       fail-fast: false

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -37,7 +37,7 @@
 		Tests for WordPress version compatibility.
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
 	-->
-	<config name="minimum_supported_wp_version" value="5.4.1"/>
+	<config name="minimum_wp_version" value="5.6"/>
 
 	<!-- Rules: WPGraphQL Coding Standards -->
 	<!-- https://github.com/AxeWP/WPGraphQL-Coding-Standards/WPGraphQL/ruleset.xml -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - chore: Update Composer dev-dependencies.
 - chore: Update WPGraphQL Coding Standards to v2.0.0-beta and lint.
+- ci: Test Plugin compatibility with WordPress 6.3.
+- chore: fix minimum supported WordPress version to be 5.6, which is the minimum requirement for RankMath 1.0.90.
 
 ## v0.0.14
 - fix: Fetch the correct SEO data when resolving custom taxonomy terms. Props @lucguerraz

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Adds WPGraphQL support for [Rank Math SEO](https://rankmath.com/). Built with [W
 
 ## System Requirements
 
-* PHP 7.4+ | 8.0+ | 8.1+
-* WordPress 5.4.1+
+* PHP 7.4 - 8.1+
+* WordPress 5.6+
 * WPGraphQL 1.8.1+
 * RankMath SEO 1.0.90+
 

--- a/bin/run-docker.sh
+++ b/bin/run-docker.sh
@@ -16,11 +16,11 @@ print_usage_instructions() {
 	echo "  composer build-app"
 	echo "  composer run-app"
 	echo ""
-	echo "  WP_VERSION=6.2 PHP_VERSION=8.1 composer build-app"
-	echo "  WP_VERSION=6.2 PHP_VERSION=8.1 composer run-app"
+	echo "  WP_VERSION=6.3 PHP_VERSION=8.1 composer build-app"
+	echo "  WP_VERSION=6.3 PHP_VERSION=8.1 composer run-app"
 	echo ""
-	echo "  WP_VERSION=6.2 PHP_VERSION=8.1  bin/run-docker.sh build -a"
-	echo "  WP_VERSION=6.2 PHP_VERSION=8.1  bin/run-docker.sh run -a"
+	echo "  WP_VERSION=6.3 PHP_VERSION=8.1  bin/run-docker.sh build -a"
+	echo "  WP_VERSION=6.3 PHP_VERSION=8.1  bin/run-docker.sh run -a"
 	exit 1
 }
 
@@ -29,7 +29,7 @@ if [ $# -eq 0 ]; then
 fi
 
 TAG=${TAG-latest}
-WP_VERSION=${WP_VERSION-6.2}
+WP_VERSION=${WP_VERSION-6.3}
 PHP_VERSION=${PHP_VERSION-8.1}
 
 BUILD_NO_CACHE=${BUILD_NO_CACHE-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   app:
     depends_on:
       - app_db
-    image: wp-graphql-rankmath:latest-wp${WP_VERSION-5.9}-php${PHP_VERSION-8.0}
+    image: wp-graphql-rankmath:latest-wp${WP_VERSION-6.3}-php${PHP_VERSION-8.1}
     volumes:
       - '.:/var/www/html/wp-content/plugins/wp-graphql-rank-math'
       - './.log/app:/var/log/apache2'
@@ -34,7 +34,7 @@ services:
   testing:
     depends_on:
       - app_db
-    image: wp-graphql-rankmath-testing:latest-wp${WP_VERSION-5.9}-php${PHP_VERSION-8.0}
+    image: wp-graphql-rankmath-testing:latest-wp${WP_VERSION-6.3}-php${PHP_VERSION-8.1}
     volumes:
       - '.:/var/www/html/wp-content/plugins/wp-graphql-rank-math'
       - './.log/testing:/var/log/apache2'

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === WPGraphQL for Rank Math ===
 Contributors: axepress, justlevine
 Tags: GraphQL, Gatsby, Headless, WPGraphQL, React, Rest, RankMath, Seo, Schema
-Requires at least: 5.4.1
-Tested up to: 6.2.2
+Requires at least: 5.6
+Tested up to: 6.3.1
 Requires PHP: 7.4
 Requires WPGraphQL: 1.8.1
 Stable tag: 0.0.14

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'axepress/wp-graphql-rank-math',
         'pretty_version' => 'dev-develop',
         'version' => 'dev-develop',
-        'reference' => '55afee4d6df84c8e612a27fc7d93787411f9d0e2',
+        'reference' => 'a7f0c1c0c232ba9d1e6908d84d6b1f9e5b181c5e',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -22,7 +22,7 @@
         'axepress/wp-graphql-rank-math' => array(
             'pretty_version' => 'dev-develop',
             'version' => 'dev-develop',
-            'reference' => '55afee4d6df84c8e612a27fc7d93787411f9d0e2',
+            'reference' => 'a7f0c1c0c232ba9d1e6908d84d6b1f9e5b181c5e',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/wp-graphql-rank-math.php
+++ b/wp-graphql-rank-math.php
@@ -10,8 +10,8 @@
  * Version: 0.0.14
  * Text Domain: wp-graphql-rank-math
  * Domain Path: /languages
- * Requires at least: 5.4.1
- * Tested up to: 6.2.2
+ * Requires at least: 5.6
+ * Tested up to: 6.3.1
  * Requires PHP: 7.4
  * WPGraphQL requires at least: 1.8.1
  * License: GPL-3


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
Ensures compatibility with latest versions of WPGraphQL and Rank Math.

Additionally, changes the minimum version of WP to 5.6. This is _not_ a breaking change, as its the minimum version required by Rank Math v1.0.90.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md
