### PR TITLE
Sitemap: `post__not_in` requires a value to be an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ## Unreleased
 
-## v0.0.16
-
-- fix: Return sitemap without excluded IDs.
+- fix: Correctly parse excluded Post/Term IDs when returning nodes for Sitemap. Props @marcinkrzeminski
 
 ## v0.0.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v0.0.16
+
+- fix: Return sitemap without excluded IDs.
+
 ## v0.0.15
 
 - chore: Update Composer dev-dependencies.

--- a/src/Type/WPObject/Settings/Sitemap/ContentType.php
+++ b/src/Type/WPObject/Settings/Sitemap/ContentType.php
@@ -41,7 +41,7 @@ class ContentType extends ObjectType implements TypeWithConnections {
 					$excluded_post_ids = Helper::get_settings( 'sitemap.exclude_posts' );
 
 					if ( ! empty( $excluded_post_ids ) ) {
-						$resolver->set_query_arg( 'post__not_in', $excluded_post_ids );
+						$resolver->set_query_arg( 'post__not_in', array_map( 'absint', explode( ',', $excluded_post_ids ) ) );
 					}
 
 					return $resolver->get_connection();

--- a/src/Type/WPObject/Settings/Sitemap/ContentType.php
+++ b/src/Type/WPObject/Settings/Sitemap/ContentType.php
@@ -30,7 +30,7 @@ class ContentType extends ObjectType implements TypeWithConnections {
 		return [
 			'connectedContentNodes' => [
 				'toType'      => 'ContentNode',
-				'description' => __( 'The connected authors whose URLs are included in the sitemap', 'wp-graphql-rank-math' ),
+				'description' => __( 'The connected content nodes whose URLs are included in the sitemap', 'wp-graphql-rank-math' ),
 				'resolve'     => static function ( $source, $args, $context, $info ) {
 					if ( empty( $source['isInSitemap'] ) ) {
 						return null;
@@ -39,9 +39,10 @@ class ContentType extends ObjectType implements TypeWithConnections {
 					$resolver = new PostObjectConnectionResolver( $source, $args, $context, $info, $source['type'] );
 
 					$excluded_post_ids = Helper::get_settings( 'sitemap.exclude_posts' );
+					$excluded_post_ids = ! empty( $excluded_post_ids ) ? array_map( 'absint', explode( ',', $excluded_post_ids ) ) : null;
 
 					if ( ! empty( $excluded_post_ids ) ) {
-						$resolver->set_query_arg( 'post__not_in', array_map( 'absint', explode( ',', $excluded_post_ids ) ) );
+						$resolver->set_query_arg( 'post__not_in', $excluded_post_ids );
 					}
 
 					return $resolver->get_connection();

--- a/src/Type/WPObject/Settings/Sitemap/Taxonomy.php
+++ b/src/Type/WPObject/Settings/Sitemap/Taxonomy.php
@@ -30,7 +30,7 @@ class Taxonomy extends ObjectType implements TypeWithConnections {
 		return [
 			'connectedTerms' => [
 				'toType'      => 'TermNode',
-				'description' => __( 'The connected authors whose URLs are included in the sitemap', 'wp-graphql-rank-math' ),
+				'description' => __( 'The connected terms whose URLs are included in the sitemap', 'wp-graphql-rank-math' ),
 				'resolve'     => static function ( $source, $args, $context, $info ) {
 					if ( empty( $source['isInSitemap'] ) ) {
 						return null;
@@ -39,6 +39,7 @@ class Taxonomy extends ObjectType implements TypeWithConnections {
 					$resolver = new TermObjectConnectionResolver( $source, $args, $context, $info, $source['type'] );
 
 					$excluded_term_ids = Helper::get_settings( 'sitemap.exclude_terms' );
+					$excluded_term_ids = ! empty( $excluded_term_ids ) ? array_map( 'absint', explode( ',', $excluded_term_ids ) ) : null;
 
 					if ( ! empty( $excluded_term_ids ) ) {
 						$resolver->set_query_arg( 'exclude', $excluded_term_ids );


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

I was getting an error saying: `array_map(): Argument #2 ($array) must be of type array, string given` when I have defined IDs to be excluded from the sitemap.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

Getting an array by exploding the string and using `array_map` with an `absint` (like it's done in other places in the plugin).

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [X] The changes in this PR have been noted in CHANGELOG.md
