### PR TITLE
fix: deprecate `sitemaps.general.canPingSearchEngines`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: Deprecate `rankMathSettings.sitemaps.general.canPingSearchEngines`, as it was remove in RankMath v1.0.211.
+
 ## v0.0.16
 
 - fix: Correctly parse excluded Post/Term IDs when returning nodes for Sitemap. Props @marcinkrzeminski

--- a/src/Model/Settings.php
+++ b/src/Model/Settings.php
@@ -362,7 +362,7 @@ class Settings extends Model {
 	 */
 	private function sitemap_general_fields(): array {
 		return [
-			'canPingSearchEngines'    => ! empty( $this->data['sitemap']['ping_search_engines'] ),
+			'canPingSearchEngines'    => false,
 			'excludedPostDatabaseIds' => ! empty( $this->data['sitemap']['exclude_posts'] ) ? array_map( 'absint', explode( ',', $this->data['sitemap']['exclude_posts'] ) ) : null,
 			'excludedTermDatabaseIds' => ! empty( $this->data['sitemap']['exclude_terms'] ) ? array_map( 'absint', explode( ',', $this->data['sitemap']['exclude_terms'] ) ) : null,
 			'hasFeaturedImage'        => ! empty( $this->data['sitemap']['include_featured_image'] ),

--- a/src/Type/WPObject/Settings/Sitemap/General.php
+++ b/src/Type/WPObject/Settings/Sitemap/General.php
@@ -33,8 +33,9 @@ class General extends ObjectType {
 	public static function get_fields(): array {
 		return [
 			'canPingSearchEngines'    => [
-				'type'        => 'Boolean',
-				'description' => __( 'Whether to notify search engines when the sitemap is updated.', 'wp-graphql-rank-math' ),
+				'type'              => 'Boolean',
+				'deprecationReason' => __( 'This feature is no longer supported by Google, and has been removed from RankMath v1.0.211+.', 'wp-graphql-rank-math' ),
+				'description'       => __( 'Whether to notify search engines when the sitemap is updated.', 'wp-graphql-rank-math' ),
 			],
 			'excludedPostDatabaseIds' => [
 				'type'        => [ 'list_of' => 'Int' ],

--- a/tests/wpunit/SettingsQueriesTest.php
+++ b/tests/wpunit/SettingsQueriesTest.php
@@ -504,7 +504,6 @@ class SettingsQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 						}
 					}
 					general {
-						canPingSearchEngines
 						excludedPostDatabaseIds
 						excludedTermDatabaseIds
 						hasFeaturedImage
@@ -573,7 +572,6 @@ class SettingsQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 								$this->expectedObject(
 									'general',
 									[
-										$this->expectedField( 'canPingSearchEngines', true ),
 										$this->expectedField( 'excludedPostDatabaseIds', static::IS_NULL ),
 										$this->expectedField( 'excludedTermDatabaseIds', static::IS_NULL ),
 										$this->expectedField( 'hasFeaturedImage', false ),


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR deprecates the `rankMathGeneral.sitemaps.general.canPingSearchEngines` field.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
It was removed from [RM 1.0.211](https://rankmath.com/changelog/free/), since the feature is no longer supported by Google.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md
