### PR TITLE
feat: expose additionalProfiles field to the social settings

### DIFF
--- a/src/Model/Settings.php
+++ b/src/Model/Settings.php
@@ -9,6 +9,7 @@ namespace WPGraphQL\RankMath\Model;
 
 use Exception;
 use RankMath\Helper;
+use RankMath\Helpers\Arr;
 use RankMath\Sitemap\Router;
 use WPGraphQL\Model\Model;
 
@@ -214,7 +215,7 @@ class Settings extends Model {
 			'facebookAdminId'    => ! empty( $this->data['titles']['facebook_admin_id'] ) ? $this->data['titles']['facebook_admin_id'] : null,
 			'facebookAppId'      => ! empty( $this->data['titles']['facebook_app_id'] ) ? $this->data['titles']['facebook_app_id'] : null,
 			'twitterAuthorName'  => ! empty( $this->data['titles']['twitter_author_names'] ) ? $this->data['titles']['twitter_author_names'] : null,
-			'additionalProfiles' => ! empty( $this->data['titles']['social_additional_profiles'] ) ? explode( ',', $this->data['titles']['social_additional_profiles'] ) : null,
+			'additionalProfiles' => ! empty( $this->data['titles']['social_additional_profiles'] ) ? Arr::from_string( $this->data['titles']['social_additional_profiles'], PHP_EOL ) : null,
 		];
 	}
 

--- a/src/Model/Settings.php
+++ b/src/Model/Settings.php
@@ -209,11 +209,12 @@ class Settings extends Model {
 	 */
 	private function meta_social_fields(): array {
 		return [
-			'facebookPageUrl'   => ! empty( $this->data['titles']['social_url_facebook'] ) ? $this->data['titles']['social_url_facebook'] : null,
-			'facebookAuthorUrl' => ! empty( $this->data['titles']['facebook_author_urls'] ) ? $this->data['titles']['facebook_author_urls'] : null,
-			'facebookAdminId'   => ! empty( $this->data['titles']['facebook_admin_id'] ) ? $this->data['titles']['facebook_admin_id'] : null,
-			'facebookAppId'     => ! empty( $this->data['titles']['facebook_app_id'] ) ? $this->data['titles']['facebook_app_id'] : null,
-			'twitterAuthorName' => ! empty( $this->data['titles']['twitter_author_names'] ) ? $this->data['titles']['twitter_author_names'] : null,
+			'facebookPageUrl'    => ! empty( $this->data['titles']['social_url_facebook'] ) ? $this->data['titles']['social_url_facebook'] : null,
+			'facebookAuthorUrl'  => ! empty( $this->data['titles']['facebook_author_urls'] ) ? $this->data['titles']['facebook_author_urls'] : null,
+			'facebookAdminId'    => ! empty( $this->data['titles']['facebook_admin_id'] ) ? $this->data['titles']['facebook_admin_id'] : null,
+			'facebookAppId'      => ! empty( $this->data['titles']['facebook_app_id'] ) ? $this->data['titles']['facebook_app_id'] : null,
+			'twitterAuthorName'  => ! empty( $this->data['titles']['twitter_author_names'] ) ? $this->data['titles']['twitter_author_names'] : null,
+			'additionalProfiles' => ! empty( $this->data['titles']['social_additional_profiles'] ) ? $this->data['titles']['social_additional_profiles'] : null,
 		];
 	}
 

--- a/src/Model/Settings.php
+++ b/src/Model/Settings.php
@@ -214,7 +214,7 @@ class Settings extends Model {
 			'facebookAdminId'    => ! empty( $this->data['titles']['facebook_admin_id'] ) ? $this->data['titles']['facebook_admin_id'] : null,
 			'facebookAppId'      => ! empty( $this->data['titles']['facebook_app_id'] ) ? $this->data['titles']['facebook_app_id'] : null,
 			'twitterAuthorName'  => ! empty( $this->data['titles']['twitter_author_names'] ) ? $this->data['titles']['twitter_author_names'] : null,
-			'additionalProfiles' => ! empty( $this->data['titles']['social_additional_profiles'] ) ? $this->data['titles']['social_additional_profiles'] : null,
+			'additionalProfiles' => ! empty( $this->data['titles']['social_additional_profiles'] ) ? explode( ',', $this->data['titles']['social_additional_profiles'] ) : null,
 		];
 	}
 

--- a/src/Type/WPObject/Settings/Meta/SocialMeta.php
+++ b/src/Type/WPObject/Settings/Meta/SocialMeta.php
@@ -32,25 +32,29 @@ class SocialMeta extends ObjectType {
 	 */
 	public static function get_fields(): array {
 		return [
-			'facebookPageUrl'   => [
+			'facebookPageUrl'    => [
 				'type'        => 'String',
 				'description' => __( 'The complete Facebook page URL.', 'wp-graphql-rank-math' ),
 			],
-			'facebookAuthorUrl' => [
+			'facebookAuthorUrl'  => [
 				'type'        => 'String',
 				'description' => __( 'The personal Facebook profile URL used to show authorship when articles are shared on Facebook.', 'wp-graphql-rank-math' ),
 			],
-			'facebookAdminId'   => [
+			'facebookAdminId'    => [
 				'type'        => [ 'list_of' => 'Int' ],
 				'description' => __( 'A list of numeric Facebook admin User Ids.', 'wp-graphql-rank-math' ),
 			],
-			'facebookAppId'     => [
+			'facebookAppId'      => [
 				'type'        => 'Int',
 				'description' => __( 'The facebook Facebook app ID.', 'wp-graphql-rank-math' ),
 			],
-			'twitterAuthorName' => [
+			'twitterAuthorName'  => [
 				'type'        => 'String',
 				'description' => __( 'Twitter Username of the auther used in the `twitter:creater` tag.', 'wp-graphql-rank-math' ),
+			],
+			'additionalProfiles' => [
+				'type'        => 'String',
+				'description' => __( 'Additional social profile URLs.', 'wp-graphql-rank-math' ),
 			],
 		];
 	}

--- a/src/Type/WPObject/Settings/Meta/SocialMeta.php
+++ b/src/Type/WPObject/Settings/Meta/SocialMeta.php
@@ -54,7 +54,7 @@ class SocialMeta extends ObjectType {
 			],
 			'additionalProfiles' => [
 				'type'        => [ 'list_of' => 'String' ],
-				'description' => __( 'Additional social profile URLs.', 'wp-graphql-rank-math' ),
+				'description' => __( 'Additional social profile URLs to add to the sameAs property for the Organization Schema.', 'wp-graphql-rank-math' ),
 			],
 		];
 	}

--- a/src/Type/WPObject/Settings/Meta/SocialMeta.php
+++ b/src/Type/WPObject/Settings/Meta/SocialMeta.php
@@ -53,7 +53,7 @@ class SocialMeta extends ObjectType {
 				'description' => __( 'Twitter Username of the auther used in the `twitter:creater` tag.', 'wp-graphql-rank-math' ),
 			],
 			'additionalProfiles' => [
-				'type'        => 'String',
+				'type'        => [ 'list_of' => 'String' ],
 				'description' => __( 'Additional social profile URLs.', 'wp-graphql-rank-math' ),
 			],
 		];

--- a/tests/wpunit/SettingsQueriesTest.php
+++ b/tests/wpunit/SettingsQueriesTest.php
@@ -310,6 +310,7 @@ class SettingsQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 						facebookAuthorUrl
 						facebookPageUrl
 						twitterAuthorName
+						additionalProfiles
 					}
 					taxonomies {
 						category {
@@ -432,6 +433,7 @@ class SettingsQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 										$this->expectedField( 'faceboookAuthorUrl', static::IS_NULL ),
 										$this->expectedField( 'facebookPageUrl', static::IS_NULL ),
 										$this->expectedField( 'twitterAuthorName', static::IS_NULL ),
+										$this->expectedField( 'additionalProfiles', static::IS_NULL ),
 									]
 								),
 								$this->expectedObject(

--- a/tests/wpunit/SettingsQueriesTest.php
+++ b/tests/wpunit/SettingsQueriesTest.php
@@ -615,5 +615,4 @@ class SettingsQueriesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		update_option( 'rank-math-options-titles', $title_options );
 	}
-
 }


### PR DESCRIPTION
## What
This PR exposes the `additionalProfiles` field to the social settings, i.e.

```
rankMathSettings {
    meta {
      social {
        facebookPageUrl
        twitterAuthorName
        additionalProfiles <----
      }
    }
  }
```

## Why
The Rank Math plugin allows us to add other social profiles apart from the Facebook URLs and the Twitter username. Therefore this field needs to be added to the GraphQL schema.

## How

## Testing Instructions
1. From the Rank Math Settings -> Titles & Meta -> Social Meta
2. Add a single URL or a list of comma-separated URLs to the `Additional Profiles` field
3. Use the query above in the GraphiQL IDE

## Additional Info

## Checklist:
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [ ] The changes in this PR have been noted in CHANGELOG.md
