### PR TITLE
fix: Correctly resolve `seo.openGraph.image` field when parsed value is a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: Correctly resolve `seo.openGraph.image` field when parsed value is a string.
+
 ## v0.1.0
 
 This _minor_ release bumps the plugin version to 0.1.0! However, there are **no breaking changes** in this release.

--- a/src/Model/Seo.php
+++ b/src/Model/Seo.php
@@ -297,7 +297,7 @@ abstract class Seo extends Model {
 				if ( ! isset( $pointer[ $part ] ) ) {
 					$pointer[ $part ] = [];
 				} elseif ( ! is_array( $pointer[ $part ] ) ) {
-					$pointer[ $part ] = [$pointer[ $part ]];
+					$pointer[ $part ] = [ $pointer[ $part ] ];
 				}
 
 				$pointer = &$pointer[ $part ];

--- a/src/Model/Seo.php
+++ b/src/Model/Seo.php
@@ -293,8 +293,11 @@ abstract class Seo extends Model {
 
 			// Loop through each part and build the array.
 			foreach ( $parts as $part ) {
+				// Ensure the part is an array.
 				if ( ! isset( $pointer[ $part ] ) ) {
 					$pointer[ $part ] = [];
+				} elseif ( ! is_array( $pointer[ $part ] ) ) {
+					$pointer[ $part ] = [$pointer[ $part ]];
 				}
 
 				$pointer = &$pointer[ $part ];

--- a/src/Type/WPObject/OpenGraphMeta.php
+++ b/src/Type/WPObject/OpenGraphMeta.php
@@ -61,16 +61,10 @@ class OpenGraphMeta extends ObjectType {
 				'type'        => OpenGraph\Image::get_type_name(),
 				'description' => __( 'The OpenGraph image meta', 'wp-graphql-rank-math' ),
 				'resolve'     => static function ( $source ): ?array {
-					$values = [];
-
-					// The URL is stored in it's own key.
-					if ( ! empty( $source['og']['image'] ) ) {
-						$values['url'] = $source['og']['image'];
-					}
-
-					// The rest of the data is stored in an array.
-					if ( ! empty( $source['og:image'] ) ) {
-						$values = array_merge( $values, $source['og:image'] );
+					$values = ! empty( $source['og']['image'] ) ? $source['og']['image'] : [];
+					
+					if ( ! empty( $source['og']['image'][0] ) ) {
+						$values['url'] = $source['og']['image'][0];
 					}
 
 					return ! empty( $values ) ? $values : null;


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
This PR fixes a bug where an OpenGraph image passed as an URL would cause a fatal error during the meta tag parsing.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

Fixes regression in #69 

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md
