### PR TITLE
chore: declare `strict_types`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix: Plugin versions in dependency check logic is now in sync with the version requirements.
 - chore!: Add `WPGraphQL/RankMath` namespace to root-level files ( `activation.php`, `deactivation.php`, `wp-graphql-rank-math.php` ).
+- chore: Declare `strict_types` in all PHP files.
 - chore: Refactor autoloader logic to `Autoloader` class.
 - chore: Update Composer dev-deps and fix newly-surfaced PHPCS smells.
 - chore: Implement PHPStan strict rules.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fix: Plugin versions in dependency check logic is now in sync with the version requirements.
+- fix: Update the return type of the `type` field in the `Redirection` model to correctly return a `?string`.
 - chore!: Add `WPGraphQL/RankMath` namespace to root-level files ( `activation.php`, `deactivation.php`, `wp-graphql-rank-math.php` ).
 - chore: Declare `strict_types` in all PHP files.
 - chore: Refactor autoloader logic to `Autoloader` class.

--- a/access-functions.php
+++ b/access-functions.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL/RankMath
  */
 
+declare( strict_types = 1 );
+
 if ( ! function_exists( 'graphql_seo_get_setting' ) ) {
 	/**
 	 * Get an option value from the plugin settings.

--- a/activation.php
+++ b/activation.php
@@ -5,6 +5,8 @@
  * @package WPGraphql\RankMath
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath;
 
 /**

--- a/deactivation.php
+++ b/deactivation.php
@@ -5,6 +5,8 @@
  * @package WPGraphql\RankMath
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath;
 
 /**

--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Admin\Settings
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Admin\Settings;
 
 use WPGraphQL\Admin\Settings\SettingsRegistry;

--- a/src/CoreSchemaFilters.php
+++ b/src/CoreSchemaFilters.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Interfaces\Registrable;

--- a/src/Fields/RootQuery.php
+++ b/src/Fields/RootQuery.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\Fields
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Fields;
 
 use WPGraphQL\RankMath\Model\Settings as ModelSettings;

--- a/src/Main.php
+++ b/src/Main.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath;
 
 use RankMath\Helper as RMHelper;

--- a/src/Model/ContentNodeSeo.php
+++ b/src/Model/ContentNodeSeo.php
@@ -5,6 +5,8 @@
  * @package \WPGraphQL\RankMath\Model
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Model;
 
 use GraphQL\Error\Error;

--- a/src/Model/ContentTypeSeo.php
+++ b/src/Model/ContentTypeSeo.php
@@ -5,6 +5,8 @@
  * @package \WPGraphQL\RankMath\Model
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Model;
 
 use GraphQL\Error\Error;

--- a/src/Model/Seo.php
+++ b/src/Model/Seo.php
@@ -5,6 +5,8 @@
  * @package \WPGraphQL\RankMath\Model
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Model;
 
 use RankMath\Frontend\Breadcrumbs as RMBreadcrumbs;

--- a/src/Model/Settings.php
+++ b/src/Model/Settings.php
@@ -5,6 +5,8 @@
  * @package \WPGraphQL\RankMath\Model
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Model;
 
 use Exception;

--- a/src/Model/TermNodeSeo.php
+++ b/src/Model/TermNodeSeo.php
@@ -5,6 +5,8 @@
  * @package \WPGraphQL\RankMath\Model
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Model;
 
 use GraphQL\Error\Error;

--- a/src/Model/UserSeo.php
+++ b/src/Model/UserSeo.php
@@ -5,6 +5,8 @@
  * @package \WPGraphQL\RankMath\Model
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Model;
 
 use GraphQL\Error\Error;

--- a/src/Modules/Redirection/Connection/RedirectionConnection.php
+++ b/src/Modules/Redirection/Connection/RedirectionConnection.php
@@ -6,6 +6,8 @@
  * @since 0.0.13
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Modules\Redirection\Connection;
 
 use GraphQL\Type\Definition\ResolveInfo;

--- a/src/Modules/Redirection/CoreSchemaFilters.php
+++ b/src/Modules/Redirection/CoreSchemaFilters.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Modules\Redirection
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Modules\Redirection;
 
 use WPGraphQL\AppContext;

--- a/src/Modules/Redirection/Data/Connection/RedirectionConnectionResolver.php
+++ b/src/Modules/Redirection/Data/Connection/RedirectionConnectionResolver.php
@@ -6,6 +6,8 @@
  * @since 0.0.13
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Modules\Redirection\Data\Connection;
 
 use WPGraphQL\Data\Connection\AbstractConnectionResolver;

--- a/src/Modules/Redirection/Data/Cursor/RedirectionCursor.php
+++ b/src/Modules/Redirection/Data/Cursor/RedirectionCursor.php
@@ -6,6 +6,8 @@
  * @since 0.0.13
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Modules\Redirection\Data\Cursor;
 
 use WPGraphQL\RankMath\Utils\RMUtils;

--- a/src/Modules/Redirection/Data/Loader/RedirectionsLoader.php
+++ b/src/Modules/Redirection/Data/Loader/RedirectionsLoader.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Modules\Redirection\Data\Loader
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Modules\Redirection\Data\Loader;
 
 use GraphQL\Error\UserError;

--- a/src/Modules/Redirection/Fields/GeneralSettings.php
+++ b/src/Modules/Redirection/Fields/GeneralSettings.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\Fields
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Modules\Redirection\Fields;
 
 use WPGraphQL\RankMath\Modules\Redirection\Type\WPObject\RedirectionSettings;

--- a/src/Modules/Redirection/Fields/RootQuery.php
+++ b/src/Modules/Redirection/Fields/RootQuery.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\Fields
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Modules\Redirection\Fields;
 
 use WPGraphQL\AppContext;

--- a/src/Modules/Redirection/Model/Redirection.php
+++ b/src/Modules/Redirection/Model/Redirection.php
@@ -103,7 +103,7 @@ class Redirection extends Model {
 					return ! empty( $serialized_sources ) ? maybe_unserialize( $serialized_sources ) : null;
 				},
 				'status'              => fn (): ?string => ! empty( $this->data['status'] ) ? $this->data['status'] : null,
-				'type'                => fn (): ?int => ! empty( $this->data['header_code'] ) ? $this->data['header_code'] : null,
+				'type'                => fn (): ?string => ! empty( $this->data['header_code'] ) ? $this->data['header_code'] : null,
 			];
 		}
 	}

--- a/src/Modules/Redirection/Model/Redirection.php
+++ b/src/Modules/Redirection/Model/Redirection.php
@@ -5,6 +5,8 @@
  * @package \WPGraphQL\RankMath\Modules\Redirection\Model
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Modules\Redirection\Model;
 
 use GraphQLRelay\Relay;

--- a/src/Modules/Redirection/Type/Enum/RedirectionBehaviorEnum.php
+++ b/src/Modules/Redirection/Type/Enum/RedirectionBehaviorEnum.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Modules\Redirection\Type\Enum
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Modules\Redirection\Type\Enum;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\EnumType;

--- a/src/Modules/Redirection/Type/Enum/RedirectionComparisonTypeEnum.php
+++ b/src/Modules/Redirection/Type/Enum/RedirectionComparisonTypeEnum.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Modules\Redirection\Type\Enum
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Modules\Redirection\Type\Enum;
 
 use RankMath\Helper;

--- a/src/Modules/Redirection/Type/Enum/RedirectionConnectionOrderByEnum.php
+++ b/src/Modules/Redirection/Type/Enum/RedirectionConnectionOrderByEnum.php
@@ -6,6 +6,8 @@
  * @since 0.0.13
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Modules\Redirection\Type\Enum;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\EnumType;

--- a/src/Modules/Redirection/Type/Enum/RedirectionStatusEnum.php
+++ b/src/Modules/Redirection/Type/Enum/RedirectionStatusEnum.php
@@ -6,6 +6,8 @@
  * @since 0.0.13
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Modules\Redirection\Type\Enum;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\EnumType;

--- a/src/Modules/Redirection/Type/Enum/RedirectionTypeEnum.php
+++ b/src/Modules/Redirection/Type/Enum/RedirectionTypeEnum.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Modules\Redirection\Type\Enum
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Modules\Redirection\Type\Enum;
 
 use RankMath\Helper;

--- a/src/Modules/Redirection/Type/Input/RedirectionConnectionOrderbyInput.php
+++ b/src/Modules/Redirection/Type/Input/RedirectionConnectionOrderbyInput.php
@@ -6,6 +6,8 @@
  * @since 0.0.13
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Modules\Redirection\Type\Input;
 
 use WPGraphQL\RankMath\Modules\Redirection\Type\Enum\RedirectionConnectionOrderByEnum;

--- a/src/Modules/Redirection/Type/WPObject/Redirection.php
+++ b/src/Modules/Redirection/Type/WPObject/Redirection.php
@@ -6,6 +6,8 @@
  * @since 0.0.13
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Modules\Redirection\Type\WPObject;
 
 use WPGraphQL\RankMath\Modules\Redirection\Type\Enum\RedirectionStatusEnum;

--- a/src/Modules/Redirection/Type/WPObject/RedirectionSettings.php
+++ b/src/Modules/Redirection/Type/WPObject/RedirectionSettings.php
@@ -6,6 +6,8 @@
  * @since 0.0.13
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Modules\Redirection\Type\WPObject;
 
 use WPGraphQL\RankMath\Modules\Redirection\Type\Enum\RedirectionBehaviorEnum;

--- a/src/Modules/Redirection/Type/WPObject/RedirectionSource.php
+++ b/src/Modules/Redirection/Type/WPObject/RedirectionSource.php
@@ -6,6 +6,8 @@
  * @since 0.0.13
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Modules\Redirection\Type\WPObject;
 
 use WPGraphQL\RankMath\Modules\Redirection\Type\Enum\RedirectionComparisonTypeEnum;

--- a/src/Modules/Redirection/TypeRegistry.php
+++ b/src/Modules/Redirection/TypeRegistry.php
@@ -6,6 +6,8 @@
  * @since 0.0.13
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Modules\Redirection;
 
 use WPGraphQL\RankMath\Modules\Redirection\Connection;

--- a/src/Type/Enum/ArticleTypeEnum.php
+++ b/src/Type/Enum/ArticleTypeEnum.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\Enum
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\Enum;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\EnumType;

--- a/src/Type/Enum/BulkEditingTypeEnum.php
+++ b/src/Type/Enum/BulkEditingTypeEnum.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\Enum
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\Enum;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\EnumType;

--- a/src/Type/Enum/ImagePreviewSizeEnum.php
+++ b/src/Type/Enum/ImagePreviewSizeEnum.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\Enum
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\Enum;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\EnumType;

--- a/src/Type/Enum/KnowledgeGraphTypeEnum.php
+++ b/src/Type/Enum/KnowledgeGraphTypeEnum.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\Enum
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\Enum;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\EnumType;

--- a/src/Type/Enum/OpenGraphLocaleEnum.php
+++ b/src/Type/Enum/OpenGraphLocaleEnum.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\Enum
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\Enum;
 
 use RankMath\OpenGraph\Facebook_Locale;

--- a/src/Type/Enum/OpenGraphProductAvailabilityEnum.php
+++ b/src/Type/Enum/OpenGraphProductAvailabilityEnum.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\Enum
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\Enum;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\EnumType;

--- a/src/Type/Enum/RobotsMetaValueEnum.php
+++ b/src/Type/Enum/RobotsMetaValueEnum.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\Enum
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\Enum;
 
 use RankMath\Helper;

--- a/src/Type/Enum/SeoRatingEnum.php
+++ b/src/Type/Enum/SeoRatingEnum.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\Enum
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\Enum;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\EnumType;

--- a/src/Type/Enum/SeoScorePositionEnum.php
+++ b/src/Type/Enum/SeoScorePositionEnum.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\Enum
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\Enum;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\EnumType;

--- a/src/Type/Enum/SeoScoreTemplateTypeEnum.php
+++ b/src/Type/Enum/SeoScoreTemplateTypeEnum.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\Enum
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\Enum;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\EnumType;

--- a/src/Type/Enum/SnippetTypeEnum.php
+++ b/src/Type/Enum/SnippetTypeEnum.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\Enum
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\Enum;
 
 use RankMath\Helper;

--- a/src/Type/Enum/TwitterCardTypeEnum.php
+++ b/src/Type/Enum/TwitterCardTypeEnum.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\Enum
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\Enum;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\EnumType;

--- a/src/Type/WPInterface/ContentNodeSeo.php
+++ b/src/Type/WPInterface/ContentNodeSeo.php
@@ -6,6 +6,8 @@
  * @since 0.0.8
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPInterface;
 
 use WPGraphQL\RankMath\Type\WPObject\SeoScore;

--- a/src/Type/WPInterface/MetaSettingWithArchive.php
+++ b/src/Type/WPInterface/MetaSettingWithArchive.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPInterface
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPInterface;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\InterfaceType;

--- a/src/Type/WPInterface/MetaSettingWithRobots.php
+++ b/src/Type/WPInterface/MetaSettingWithRobots.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPInterface
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPInterface;
 
 use WPGraphQL\RankMath\Type\Enum\RobotsMetaValueEnum;

--- a/src/Type/WPInterface/NodeWithSeo.php
+++ b/src/Type/WPInterface/NodeWithSeo.php
@@ -6,6 +6,8 @@
  * @since 0.0.8
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPInterface;
 
 use GraphQL\Error\UserError;

--- a/src/Type/WPInterface/Seo.php
+++ b/src/Type/WPInterface/Seo.php
@@ -6,6 +6,8 @@
  * @since 0.0.8
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPInterface;
 
 use RankMath\Helper;

--- a/src/Type/WPObject/AdvancedRobotsMeta.php
+++ b/src/Type/WPObject/AdvancedRobotsMeta.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject;
 
 use WPGraphQL\RankMath\Type\Enum\ImagePreviewSizeEnum;

--- a/src/Type/WPObject/Breadcrumbs.php
+++ b/src/Type/WPObject/Breadcrumbs.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\ObjectType;

--- a/src/Type/WPObject/JsonLd.php
+++ b/src/Type/WPObject/JsonLd.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\ObjectType;

--- a/src/Type/WPObject/OpenGraph/Article.php
+++ b/src/Type/WPObject/OpenGraph/Article.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\OpenGraph;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\ObjectType;

--- a/src/Type/WPObject/OpenGraph/Facebook.php
+++ b/src/Type/WPObject/OpenGraph/Facebook.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\OpenGraph;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\ObjectType;

--- a/src/Type/WPObject/OpenGraph/Image.php
+++ b/src/Type/WPObject/OpenGraph/Image.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\OpenGraph;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\ObjectType;

--- a/src/Type/WPObject/OpenGraph/Product.php
+++ b/src/Type/WPObject/OpenGraph/Product.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\OpenGraph;
 
 use WPGraphQL\RankMath\Type\Enum\OpenGraphProductAvailabilityEnum;

--- a/src/Type/WPObject/OpenGraph/SlackEnhancedData.php
+++ b/src/Type/WPObject/OpenGraph/SlackEnhancedData.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\OpenGraph;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\ObjectType;

--- a/src/Type/WPObject/OpenGraph/Twitter.php
+++ b/src/Type/WPObject/OpenGraph/Twitter.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\OpenGraph;
 
 use WPGraphQL\RankMath\Type\Enum\TwitterCardTypeEnum;

--- a/src/Type/WPObject/OpenGraph/TwitterApp.php
+++ b/src/Type/WPObject/OpenGraph/TwitterApp.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\OpenGraph;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\ObjectType;

--- a/src/Type/WPObject/OpenGraph/Video.php
+++ b/src/Type/WPObject/OpenGraph/Video.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\OpenGraph;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\ObjectType;

--- a/src/Type/WPObject/OpenGraphMeta.php
+++ b/src/Type/WPObject/OpenGraphMeta.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject;
 
 use WPGraphQL\RankMath\Type\Enum\OpenGraphLocaleEnum;

--- a/src/Type/WPObject/SeoObjects.php
+++ b/src/Type/WPObject/SeoObjects.php
@@ -6,6 +6,8 @@
  * @since 0.0.8
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject;
 
 use WPGraphQL;

--- a/src/Type/WPObject/SeoScore.php
+++ b/src/Type/WPObject/SeoScore.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject;
 
 use WPGraphQL\RankMath\Type\Enum\SeoRatingEnum;

--- a/src/Type/WPObject/Settings.php
+++ b/src/Type/WPObject/Settings.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject;
 
 use WPGraphQL\RankMath\Type\WPObject\Settings\General;

--- a/src/Type/WPObject/Settings/General.php
+++ b/src/Type/WPObject/Settings/General.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\Settings;
 
 use WPGraphQL\RankMath\Type\WPObject\Settings\General\BreadcrumbsConfig;

--- a/src/Type/WPObject/Settings/General/BreadcrumbsConfig.php
+++ b/src/Type/WPObject/Settings/General/BreadcrumbsConfig.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject\Settings\General
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\Settings\General;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\ObjectType;

--- a/src/Type/WPObject/Settings/General/FrontendSeoScore.php
+++ b/src/Type/WPObject/Settings/General/FrontendSeoScore.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject\Settings\General
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\Settings\General;
 
 use WPGraphQL\RankMath\Type\Enum\SeoScorePositionEnum;

--- a/src/Type/WPObject/Settings/General/Links.php
+++ b/src/Type/WPObject/Settings/General/Links.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject\Settings\General
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\Settings\General;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\ObjectType;

--- a/src/Type/WPObject/Settings/General/Webmaster.php
+++ b/src/Type/WPObject/Settings/General/Webmaster.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject\Settings\General
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\Settings\General;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\ObjectType;

--- a/src/Type/WPObject/Settings/Meta.php
+++ b/src/Type/WPObject/Settings/Meta.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\Settings;
 
 use WPGraphQL\RankMath\Type\WPObject\Settings\Meta\AuthorArchiveMeta;

--- a/src/Type/WPObject/Settings/Meta/AuthorArchiveMeta.php
+++ b/src/Type/WPObject/Settings/Meta/AuthorArchiveMeta.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject\Settings\Meta
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\Settings\Meta;
 
 use WPGraphQL\RankMath\Type\WPInterface\MetaSettingWithArchive;

--- a/src/Type/WPObject/Settings/Meta/ContentTypeMeta.php
+++ b/src/Type/WPObject/Settings/Meta/ContentTypeMeta.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject\Settings\Meta
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\Settings\Meta;
 
 use GraphQL\Error\UserError;

--- a/src/Type/WPObject/Settings/Meta/DateArchiveMeta.php
+++ b/src/Type/WPObject/Settings/Meta/DateArchiveMeta.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject\Settings\Meta
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\Settings\Meta;
 
 use WPGraphQL\RankMath\Type\WPInterface\MetaSettingWithArchive;

--- a/src/Type/WPObject/Settings/Meta/GlobalMeta.php
+++ b/src/Type/WPObject/Settings/Meta/GlobalMeta.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject\Settings\Meta
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\Settings\Meta;
 
 use WPGraphQL\AppContext;

--- a/src/Type/WPObject/Settings/Meta/HomepageMeta.php
+++ b/src/Type/WPObject/Settings/Meta/HomepageMeta.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject\Settings\Meta
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\Settings\Meta;
 
 use WPGraphQL\AppContext;

--- a/src/Type/WPObject/Settings/Meta/LocalMeta.php
+++ b/src/Type/WPObject/Settings/Meta/LocalMeta.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject\Settings\Meta
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\Settings\Meta;
 
 use WPGraphQL\AppContext;

--- a/src/Type/WPObject/Settings/Meta/SocialMeta.php
+++ b/src/Type/WPObject/Settings/Meta/SocialMeta.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject\Settings\Meta
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\Settings\Meta;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\ObjectType;

--- a/src/Type/WPObject/Settings/Meta/TaxonomyMeta.php
+++ b/src/Type/WPObject/Settings/Meta/TaxonomyMeta.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject\Settings\Meta
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\Settings\Meta;
 
 use WPGraphQL\RankMath\Type\WPInterface\MetaSettingWithArchive;

--- a/src/Type/WPObject/Settings/Sitemap.php
+++ b/src/Type/WPObject/Settings/Sitemap.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\Settings;
 
 use WPGraphQL\RankMath\Type\WPObject\Settings\Sitemap\Author;

--- a/src/Type/WPObject/Settings/Sitemap/Author.php
+++ b/src/Type/WPObject/Settings/Sitemap/Author.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject\Settings\Sitemap
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\Settings\Sitemap;
 
 use WPGraphQL\Data\Connection\UserConnectionResolver;

--- a/src/Type/WPObject/Settings/Sitemap/ContentType.php
+++ b/src/Type/WPObject/Settings/Sitemap/ContentType.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject\Settings\Sitemap
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\Settings\Sitemap;
 
 use RankMath\Helper;

--- a/src/Type/WPObject/Settings/Sitemap/General.php
+++ b/src/Type/WPObject/Settings/Sitemap/General.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject\Settings\Sitemap
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\Settings\Sitemap;
 
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Abstracts\ObjectType;

--- a/src/Type/WPObject/Settings/Sitemap/Taxonomy.php
+++ b/src/Type/WPObject/Settings/Sitemap/Taxonomy.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Type\WPObject\Settings\Sitemap
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Type\WPObject\Settings\Sitemap;
 
 use RankMath\Helper;

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath;
 
 use Exception;

--- a/src/Utils/RMUtils.php
+++ b/src/Utils/RMUtils.php
@@ -6,6 +6,8 @@
  * @since 0.0.13
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Utils;
 
 use MyThemeShop\Database\Database;

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -5,6 +5,8 @@
  * @package WPGraphQL\RankMath\Utils\Utils;
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath\Utils;
 
 /**

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'axepress/wp-graphql-rank-math',
         'pretty_version' => 'dev-develop',
         'version' => 'dev-develop',
-        'reference' => '088d49e35e0caa606761d1734ede065d5b398c29',
+        'reference' => 'a884694d521644ffc088958beafdd9272b4deece',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -22,7 +22,7 @@
         'axepress/wp-graphql-rank-math' => array(
             'pretty_version' => 'dev-develop',
             'version' => 'dev-develop',
-            'reference' => '088d49e35e0caa606761d1734ede065d5b398c29',
+            'reference' => 'a884694d521644ffc088958beafdd9272b4deece',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/wp-graphql-rank-math.php
+++ b/wp-graphql-rank-math.php
@@ -23,6 +23,8 @@
  * @version 0.1.1
  */
 
+declare( strict_types = 1 );
+
 namespace WPGraphQL\RankMath;
 
 // Exit if accessed directly.


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR adds the `declare( strict_types = 1 )` header to all plugin PHP files.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

Better type safety for enterprise.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md
