### PR TITLE
fix: improve `ContentTypeSeo` handling and breadcrumb generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - feat: Add plugin dependencies header.
+- fix: Improve handling of `ContentTypeSeo` and prevent fatal error when generating breadcrumbs. H/t @MonPetitUd
 - fix: Plugin versions in dependency check logic is now in sync with the version requirements.
 - fix: Update the return type of the `type` field in the `Redirection` model to correctly return a `?string`.
 - chore!: Add `WPGraphQL/RankMath` namespace to root-level files ( `activation.php`, `deactivation.php`, `wp-graphql-rank-math.php` ).

--- a/src/Model/ContentNodeSeo.php
+++ b/src/Model/ContentNodeSeo.php
@@ -11,6 +11,7 @@ namespace WPGraphQL\RankMath\Model;
 
 use GraphQL\Error\Error;
 use GraphQL\Error\UserError;
+use RankMath\Helper as RMHelper;
 use WPGraphQL;
 
 /**
@@ -181,6 +182,25 @@ class ContentNodeSeo extends Seo {
 				]
 			);
 		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function get_breadcrumbs(): ?array {
+		$breadcrumbs = parent::get_breadcrumbs();
+
+		if ( empty( $breadcrumbs ) ) {
+			return null;
+		}
+
+		$remove_title = ( is_single( $this->database_id ) || is_page( $this->database_id ) ) && RMHelper::get_settings( 'general.breadcrumbs_remove_post_title' );
+
+		if ( $remove_title ) {
+			array_pop( $breadcrumbs );
+		}
+
+		return ! empty( $breadcrumbs ) ? $breadcrumbs : null;
 	}
 
 	/**

--- a/src/Model/Seo.php
+++ b/src/Model/Seo.php
@@ -92,11 +92,6 @@ abstract class Seo extends Model {
 		);
 
 		parent::__construct( $capability, $allowed_fields );
-
-		// Seat up RM Globals.
-		$url = $this->get_object_url();
-
-		$this->setup_post_head( $url );
 	}
 
 	/**
@@ -107,6 +102,11 @@ abstract class Seo extends Model {
 		/** @var \RankMath\Paper\Paper $paper */
 		$paper        = Paper::get();
 		$this->helper = $paper;
+
+		// Seat up RM Globals.
+		$url = $this->get_object_url();
+
+		$this->setup_post_head( $url );
 	}
 
 	/**
@@ -169,9 +169,18 @@ abstract class Seo extends Model {
 	 */
 	protected function get_breadcrumbs(): ?array {
 		// Get the crumbs and shape them.
-		$crumbs      = RMBreadcrumbs::get()->get_crumbs();
+		$crumbs = RMBreadcrumbs::get()->get_crumbs();
+
+		if ( empty( $crumbs ) ) {
+			return null;
+		}
+
 		$breadcrumbs = array_map(
 			static function ( $crumb ) {
+				if ( empty( $crumb[1] ) && empty( $crumb[0] ) ) {
+					return null;
+				}
+
 				return [
 					'text'     => $crumb[0] ?? null,
 					'url'      => $crumb[1] ?? null,
@@ -181,11 +190,7 @@ abstract class Seo extends Model {
 			$crumbs
 		);
 
-		// Pop the current item's title.
-		$remove_title = ( is_single( $this->database_id ) || is_page( $this->database_id ) ) && RMHelper::get_settings( 'general.breadcrumbs_remove_post_title' );
-		if ( $remove_title ) {
-			array_pop( $breadcrumbs );
-		}
+		$breadcrumbs = array_filter( $breadcrumbs );
 
 		return ! empty( $breadcrumbs ) ? $breadcrumbs : null;
 	}

--- a/src/Type/WPInterface/NodeWithSeo.php
+++ b/src/Type/WPInterface/NodeWithSeo.php
@@ -79,6 +79,10 @@ class NodeWithSeo extends InterfaceType implements TypeWithInterfaces {
 						return null;
 					}
 
+					if ( empty( $source->uri ) ) {
+						return null;
+					}
+
 					$model = self::get_model_for_node( $source );
 
 					if ( empty( $model ) ) {


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR:
- Refactors breadcrumb generation so each `Model` handles its own generation.
- Improves the handling of `ContentTypeSeo` to account for Post Archives.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Fixes #81 in lieu of https://github.com/wp-graphql/wp-graphql/issues/2491

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md
