### PR TITLE
fix: correctly resolve `homepage.description`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- fix: Correctly resolve `rankMathSettings.homepage.description` field. Props @offminded 🙌
 - chore: Update Composer dev-dependencies to latest versions and address uncovered lints.
 - tests: Update compatibility with `wp-graphql-test-case@3.0.1`.
 

--- a/src/Model/Settings.php
+++ b/src/Model/Settings.php
@@ -243,7 +243,7 @@ class Settings extends Model {
 	private function meta_homepage_fields(): ?array {
 		return 'page' !== get_option( 'show_on_front' ) ? [
 			'advancedRobotsMeta'  => $this->advanced_robots_meta( 'homepage_advanced_robots' ),
-			'description'         => ! empty( $this->data['titles']['homepage_description'] ) ? $this->data['titles']['author_archive_description'] : null,
+			'description'         => ! empty( $this->data['titles']['homepage_description'] ) ? $this->data['titles']['homepage_description'] : null,
 			'hasCustomRobotsMeta' => ! empty( $this->data['titles']['homepage_custom_robots'] ),
 			'robotsMeta'          => ! empty( $this->data['titles']['homepage_robots'] ) ? $this->data['titles']['homepage_robots'] : null,
 			'socialDescription'   => ! empty( $this->data['titles']['homepage_facebook_description'] ) ? $this->data['titles']['homepage_facebook_description'] : null,


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
Fix homepage description query null return
## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [ ] My code is tested to the best of my abilities.
- [ ] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [ ] I have added unit tests to verify the code works as intended.
- [ ] The changes in this PR have been noted in CHANGELOG.md
