### PR TITLE
chore!: bump minimum WPGraphQL and use new Connection Resolver API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+- chore!: Bump minimum supported WPGraphQL version to v1.26.0.
+- dev: Update `RedirectionConnectionResolver` for v1.26.0 compatibility.
 - fix: Correctly resolve `rankMathSettings.homepage.description` field. Props @offminded 🙌
 - chore: Update Composer dev-dependencies to latest versions and address uncovered lints.
 - tests: Update compatibility with `wp-graphql-test-case@3.0.1`.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Adds WPGraphQL support for [Rank Math SEO](https://rankmath.com/). Built with [W
 
 * PHP 7.4 - 8.2+
 * WordPress 6.0+
-* WPGraphQL 1.14.0+
+* WPGraphQL 1.26.0+
 * RankMath SEO 1.0.201+
 
 ## Quick Install

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,8 @@ Tags: GraphQL, Gatsby, Headless, WPGraphQL, React, Rest, RankMath, Seo, Schema
 Requires at least: 6.0
 Tested up to: 6.5.0
 Requires PHP: 7.4
-Requires WPGraphQL: 1.14.0
+Requires Plugins: wp-graphql, seo-by-rank-math
+Requires WPGraphQL: 1.26.0
 Stable tag: 0.2.0
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/wp-graphql-rank-math.php
+++ b/wp-graphql-rank-math.php
@@ -14,7 +14,7 @@
  * Tested up to: 6.5.0
  * Requires PHP: 7.4
  * Requires Plugins: wp-graphql, seo-by-rank-math
- * WPGraphQL requires at least: 1.14.0
+ * WPGraphQL requires at least: 1.26.0
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
@@ -96,7 +96,7 @@ if ( file_exists( __DIR__ . '/deactivation.php' ) ) {
  * @return array<string, string> List of dependencies that are not ready.
  */
 function dependencies_not_ready(): array {
-	$wpgraphql_version = '1.14.0';
+	$wpgraphql_version = '1.26.0';
 	$rankmath_version  = '1.0.201';
 
 	$deps = [];


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR bumps the minimum version of WPGraphQL to v1.26.0 in order to make use of the new API methods and improved internal lifecycle included in `AbstractConnectionResolver`.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

A more stable lifecycle and improved performance.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md
