### PR TITLE
ci: test compatibility with WP 6.6.1

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -29,20 +29,15 @@ jobs:
     strategy:
       matrix:
         php: ["8.2", "8.1", "8.0"]
-        wordpress: ["6.6", "6.5", "6.4", "6.3", "6.2", "6.1", "6.0" ]
+        wordpress: ["6.6", "6.5", "6.4", "6.3" ]
         include:
           - php: "8.2"
             wordpress: "6.6"
             coverage: 1
-          # Test old versions against PHP 8.0
-          - php: "7.4"
-            wordpress: "6.1"
-          - php: "7.4"
-            wordpress: "6.0"
         exclude:
           # Old WP versions that dont support newer PHP versions
-          - php: "8.2"
-            wordpress: "6.0"
+          # - php: "8.2"
+          #   wordpress: "6.0"
           # New WP versions that dont support older PHP versions
           - php: "8.0"
             wordpress: "6.6"

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -29,10 +29,10 @@ jobs:
     strategy:
       matrix:
         php: ["8.2", "8.1", "8.0"]
-        wordpress: ["6.5", "6.4", "6.3", "6.2", "6.1", "6.0" ]
+        wordpress: ["6.6", "6.5", "6.4", "6.3", "6.2", "6.1", "6.0" ]
         include:
           - php: "8.2"
-            wordpress: "6.5"
+            wordpress: "6.6"
             coverage: 1
           # Test old versions against PHP 8.0
           - php: "7.4"
@@ -44,6 +44,8 @@ jobs:
           - php: "8.2"
             wordpress: "6.0"
           # New WP versions that dont support older PHP versions
+          - php: "8.0"
+            wordpress: "6.6"
           - php: "8.0"
             wordpress: "6.5"
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- ci: test plugin compatibility with WordPress 6.6.1.
+- ci: replace uses of deprecated `docker-compose` with `docker compose`.
+
 ## [0.3.0]
 
 This _major_ releases simplifies the GraphQL schema by narrowing the `seo` field types to their implementations. We've also bumped the minimum version of WPGraphQL to v1.26.0 and refactored the `RedirectionConnectionResolver` to use the improved lifecycle methods introduced in that release.

--- a/bin/run-docker.sh
+++ b/bin/run-docker.sh
@@ -16,11 +16,11 @@ print_usage_instructions() {
 	echo "  composer build-app"
 	echo "  composer run-app"
 	echo ""
-	echo "  WP_VERSION=6.5 PHP_VERSION=8.2 composer build-app"
-	echo "  WP_VERSION=6.5 PHP_VERSION=8.2 composer run-app"
+	echo "  WP_VERSION=6.6 PHP_VERSION=8.2 composer build-app"
+	echo "  WP_VERSION=6.6 PHP_VERSION=8.2 composer run-app"
 	echo ""
-	echo "  WP_VERSION=6.5 PHP_VERSION=8.2  bin/run-docker.sh build -a"
-	echo "  WP_VERSION=6.5 PHP_VERSION=8.2  bin/run-docker.sh run -a"
+	echo "  WP_VERSION=6.6 PHP_VERSION=8.2  bin/run-docker.sh build -a"
+	echo "  WP_VERSION=6.6 PHP_VERSION=8.2  bin/run-docker.sh run -a"
 	exit 1
 }
 
@@ -29,7 +29,7 @@ if [ $# -eq 0 ]; then
 fi
 
 TAG=${TAG-latest}
-WP_VERSION=${WP_VERSION-6.5}
+WP_VERSION=${WP_VERSION-6.6}
 PHP_VERSION=${PHP_VERSION-8.2}
 
 BUILD_NO_CACHE=${BUILD_NO_CACHE-}
@@ -83,7 +83,7 @@ case "$subcommand" in
 			WP_VERSION=${WP_VERSION} PHP_VERSION=${PHP_VERSION} docker compose up app
 			;;
 		t)
-			docker-compose run --rm \
+			docker compose run --rm \
 				-e COVERAGE=${COVERAGE-} \
 				-e USING_XDEBUG=${USING_XDEBUG-} \
 				-e DEBUG=${DEBUG-} \

--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,7 @@
 		"install-stan-env": "bash bin/install-stan-env.sh",
 		"docker-build": "bash bin/run-docker.sh build",
 		"docker-run": "bash bin/run-docker.sh run",
-		"docker-destroy": "docker-compose down",
+		"docker-destroy": "docker compose down",
 		"build-and-run": [
 			"@docker-build",
 			"@docker-run"

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: axepress, justlevine
 Tags: GraphQL, Gatsby, Headless, WPGraphQL, React, Rest, RankMath, Seo, Schema
 Requires at least: 6.0
-Tested up to: 6.5.0
+Tested up to: 6.6.1
 Requires PHP: 7.4
 Requires Plugins: wp-graphql, seo-by-rank-math
 Requires WPGraphQL: 1.26.0

--- a/wp-graphql-rank-math.php
+++ b/wp-graphql-rank-math.php
@@ -11,7 +11,7 @@
  * Text Domain: wp-graphql-rank-math
  * Domain Path: /languages
  * Requires at least: 6.0
- * Tested up to: 6.5.0
+ * Tested up to: 6.6.1
  * Requires PHP: 7.4
  * Requires Plugins: wp-graphql, seo-by-rank-math
  * WPGraphQL requires at least: 1.26.0


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR adds WP 6.6 to the test matrix, and updates the headers for 6.6.1

It also replaces `docker-compose` with `docker compose` commands, since it seems the deprecated command is no longer available on GH runners.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md
