### PR TITLE
fix: improve openGraph type handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## [Unreleased]
 
-- chore: Update Composer dev-deps.
+- fix: Improve `seo.openGraph` type handling to prevent fatal errors when resolving custom schemas. H/t @juniorzenb
 - fix: expose `RankMathSeo.canonicalUrl` to unauthenticated users. H/t @marziolek
+- chore: Update Composer dev-deps.
 - ci: test plugin compatibility with WordPress 6.6.1.
 - ci: replace uses of deprecated `docker-compose` with `docker compose`.
 - ci: Remove WP < 6.3 from GitHub Actions tests for RankMath 1.0.218+ compatibility.

--- a/src/Type/WPObject/OpenGraph/Article.php
+++ b/src/Type/WPObject/OpenGraph/Article.php
@@ -37,12 +37,12 @@ class Article extends ObjectType {
 			'modifiedTime'  => [
 				'type'        => 'String',
 				'description' => __( 'The date modified.', 'wp-graphql-rank-math' ),
-				'resolve'     => static fn ( $source ): ?string => ! empty( $source['modified_time'] ) ? $source['modified_time'] : null,
+				'resolve'     => static fn ( $source ): ?string => ! empty( $source['modified_time'] ) ? (string) $source['modified_time'] : null,
 			],
 			'publishedTime' => [
 				'type'        => 'String',
 				'description' => __( 'The date published.', 'wp-graphql-rank-math' ),
-				'resolve'     => static fn ( $source ): ?string => ! empty( $source['published_time'] ) ? $source['published_time'] : null,
+				'resolve'     => static fn ( $source ): ?string => ! empty( $source['published_time'] ) ? (string) $source['published_time'] : null,
 			],
 			'publisher'     => [
 				'type'        => 'String',
@@ -58,9 +58,16 @@ class Article extends ObjectType {
 				'resolve'     => static function ( $source ): ?array {
 					$value = ! empty( $source['tag'] ) ? $source['tag'] : null;
 
-					if ( is_string( $value ) ) {
-						$value = [ $value ];
+					if ( empty( $value ) ) {
+						return null;
 					}
+
+					if ( ! is_array( $value ) ) {
+						$value = [ (string) $value ];
+					}
+
+					// Ensure all tags are strings.
+					$value = array_map( 'strval', $value );
 
 					return $value;
 				},
@@ -68,7 +75,7 @@ class Article extends ObjectType {
 			'section'       => [
 				'type'        => 'String',
 				'description' => __( 'The article category.', 'wp-graphql-rank-math' ),
-				'resolve'     => static fn ( $source ): ?string => ! empty( $source['section'] ) ? $source['section'] : null,
+				'resolve'     => static fn ( $source ): ?string => ! empty( $source['section'] ) ? (string) $source['section'] : null,
 			],
 		];
 	}

--- a/src/Type/WPObject/OpenGraph/Facebook.php
+++ b/src/Type/WPObject/OpenGraph/Facebook.php
@@ -37,7 +37,7 @@ class Facebook extends ObjectType {
 			'appId'  => [
 				'type'        => 'ID',
 				'description' => __( 'The Facebook app ID associated with this resource', 'wp-graphql-rank-math' ),
-				'resolve'     => static fn ( $source ): ?string => ! empty( $source['app_id'] ) ? $source['app_id'] : null,
+				'resolve'     => static fn ( $source ): ?string => ! empty( $source['app_id'] ) ? (string) $source['app_id'] : null,
 			],
 			'admins' => [
 				'type'        => [ 'list_of' => 'String' ],
@@ -45,9 +45,16 @@ class Facebook extends ObjectType {
 				'resolve'     => static function ( $source ): ?array {
 					$value = ! empty( $source['admins'] ) ? $source['admins'] : null;
 
-					if ( is_string( $value ) ) {
-						$value = [ $value ];
+					if ( empty( $value ) ) {
+						return null;
 					}
+
+					if ( ! is_array( $value ) ) {
+						$value = [ (string) $value ];
+					}
+
+					// Ensure all tags are strings.
+					$value = array_map( 'strval', $value );
 
 					return $value;
 				},

--- a/src/Type/WPObject/OpenGraph/Image.php
+++ b/src/Type/WPObject/OpenGraph/Image.php
@@ -41,7 +41,7 @@ class Image extends ObjectType {
 			'secureUrl' => [
 				'type'        => 'String',
 				'description' => __( 'The https:// URL for the image.', 'wp-graphql-rank-math' ),
-				'resolve'     => static fn ( $source ): ?string => ! empty( $source['secure_url'] ) ? $source['secure_url'] : null,
+				'resolve'     => static fn ( $source ): ?string => ! empty( $source['secure_url'] ) ? (string) $source['secure_url'] : null,
 			],
 			'type'      => [
 				'type'        => 'String', // @todo

--- a/src/Type/WPObject/OpenGraph/Product.php
+++ b/src/Type/WPObject/OpenGraph/Product.php
@@ -43,14 +43,14 @@ class Product extends ObjectType {
 				'type'        => 'Float',
 				'description' => __( 'The price of the object', 'wp-graphql-rank-math' ),
 				'resolve'     => static function ( $source ): ?float {
-					return ! empty( $source['price']['amount'] ) ? $source['price']['amount'] : null;
+					return ! empty( $source['price']['amount'] ) ? (float) $source['price']['amount'] : null;
 				},
 			],
 			'currency'     => [
 				'type'        => 'String',
 				'description' => __( 'The currency of the object price.', 'wp-graphql-rank-math' ),
 				'resolve'     => static function ( $source ): ?string {
-					return ! empty( $source['price']['currency'] ) ? $source['price']['currency'] : null;
+					return ! empty( $source['price']['currency'] ) ? (string) $source['price']['currency'] : null;
 				},
 			],
 			'availability' => [

--- a/src/Type/WPObject/OpenGraph/Twitter.php
+++ b/src/Type/WPObject/OpenGraph/Twitter.php
@@ -50,7 +50,7 @@ class Twitter extends ObjectType {
 			'appCountry'              => [
 				'type'        => 'String',
 				'description' => __( 'The app country.', 'wp-graphql-rank-math' ),
-				'resolve'     => static fn ( $source ): ?string => ! empty( $source['app:country'] ) ? $source['app:country'] : null,
+				'resolve'     => static fn ( $source ): ?string => ! empty( $source['app:country'] ) ? (string) $source['app:country'] : null,
 			],
 			'ipadApp'                 => [
 				'type'        => TwitterApp::get_type_name(),
@@ -68,14 +68,14 @@ class Twitter extends ObjectType {
 				'resolve'     => static fn ( $source ): ?array => self::get_app_meta( $source, 'googleplay' ),
 			],
 			'playerUrl'               => [
-				'type'        => 'Integer',
+				'type'        => 'Int',
 				'description' => __( 'URL of the twitter player.', 'wp-graphql-rank-math' ),
-				'resolve'     => static fn ( $source ): ?int => ! empty( $source['player'] ) ? $source['player'] : null,
+				'resolve'     => static fn ( $source ): ?int => ! empty( $source['player'] ) ? (int) $source['player'] : null,
 			],
 			'playerStream'            => [
 				'type'        => 'String',
 				'description' => __( 'URL to raw video or audio stream', 'wp-graphql-rank-math' ),
-				'resolve'     => static fn ( $source ): ?int => ! empty( $source['player:stream'] ) ? $source['player:stream'] : null,
+				'resolve'     => static fn ( $source ): ?string => ! empty( $source['player:stream'] ) ? (string) $source['player:stream'] : null,
 			],
 			'site'                    => [
 				'type'        => 'String',
@@ -84,7 +84,7 @@ class Twitter extends ObjectType {
 			'playerStreamContentType' => [
 				'type'        => 'String',
 				'description' => __( 'The content type of the stream', 'wp-graphql-rank-math' ),
-				'resolve'     => static fn ( $source ): ?int => ! empty( $source['player:stream:content_type'] ) ? $source['player:stream:content_type'] : null,
+				'resolve'     => static fn ( $source ): ?string => ! empty( $source['player:stream:content_type'] ) ? (string) $source['player:stream:content_type'] : null,
 			],
 			'image'                   => [
 				'type'        => 'String',


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR guards against PHP fatal errors when resolving `OpenGraph` data, by defensively type casting any `resolve` callbacks that return a specific PHP type.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

RM doesn't sanitize for types when using custom open graph values. This is readily apparent in RM pro, but also afffects RM free, due to how filters get applied.

Fixes #98 

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md
