### PR TITLE
fix: use `Post::$databaseId` to prevent fatals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- fix: Prevent fatal error when resolving seo from private `Post` models. H/t @MonPetitUd
+
 ## [0.3.1]
 
 This _minor_ release fixes several bugs and improves compatibility with WPGraphQL for WooCommerce.

--- a/src/Type/WPInterface/NodeWithSeo.php
+++ b/src/Type/WPInterface/NodeWithSeo.php
@@ -124,7 +124,7 @@ class NodeWithSeo extends InterfaceType implements TypeWithInterfaces {
 		// A map of the node models to their corresponding SEO model classes.
 		switch ( true ) {
 			case $node_model instanceof \WPGraphQL\Model\Post:
-				$seo_model = new ContentNodeSeo( $node_model->ID );
+				$seo_model = new ContentNodeSeo( $node_model->databaseId );
 				break;
 			case $node_model instanceof \WPGraphQL\Model\PostType:
 				$seo_model = new ContentTypeSeo( $node_model->name );


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR fixes an issue in `NodeWithSeo` so the model is resolved using `Post::$databaseId` instead of `Post::$ID`

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

On private posts, the `Post::$ID` is protected, leading to potential fatal errors with strict types.

Fixes #108 

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md
