### PR TITLE
dev: add GraphQL Debug message to response when attempting to use `Page.seo` for the Posts Archive.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- dev: Add GraphQL Debug message to response when attempting to use `Page.seo` for the Posts Archive.
 - chore: Update Composer dev-deps.
 
 ## [0.3.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- dev: Add GraphQL Debug message to response when attempting to use `Page.seo` for the Posts Archive.
+- dev: Add GraphQL Debug message to response when attempting to use `Page.seo` for the Posts Archive. H/t @amoyanoakqa
 - chore: Update Composer dev-deps.
 
 ## [0.3.2]

--- a/src/Type/WPInterface/NodeWithSeo.php
+++ b/src/Type/WPInterface/NodeWithSeo.php
@@ -87,6 +87,20 @@ class NodeWithSeo extends InterfaceType implements TypeWithInterfaces {
 					}
 
 					if ( empty( $source->uri ) ) {
+						/**
+						 * This can occur when querying the `Posts` page, since the Model "casts" it as a `ContentType` due to the lack of archive support.
+						 *
+						 * @see \WPGraphQL\Model\Post::$uri
+						 */
+						if ( $source instanceof \WPGraphQL\Model\Post && $source->isPostsPage ) {
+							graphql_debug(
+								sprintf(
+									// translators: %d: The ID of the Post model being queried.
+									esc_html__( 'Post %d is configured as the Posts archive, but is being queried as a `Page`. To get the SEO data, please query the object as a `ContentType` (e.g. via `nodeByUri`).', 'wp-graphql-rank-math' ),
+									$source->databaseId,
+								)
+							);
+						}
 						return null;
 					}
 


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR adds a `graphql_debug()` message when `null` is returned from a `Page.seo` on the Posts archive

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

Since WPGraphQL doesn't have an archive type, it treats the `page_for_posts` WP_Post object as a `ContentType` instead of content node. ( See the discussion on #2486 ). 

As that's not readily obvious, a debug message directing them to use `contentType` or `nodeByUri` will let them know that it's returning null for a reason. 
 
Closes #111

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

If the URI is null __and__ the a `Post` model is for the Posts Page, logs a message to `extensions.debug`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->
![image](https://github.com/user-attachments/assets/de7f3aa1-d338-4538-833c-5bd327938101)

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md
