### PR TITLE
Fix WooGraphQL Product Type Expectations

### DIFF
--- a/src/Extensions/WPGraphQLWooCommerce/Type/WPObject/SeoObjects.php
+++ b/src/Extensions/WPGraphQLWooCommerce/Type/WPObject/SeoObjects.php
@@ -34,34 +34,22 @@ class SeoObjects implements Registrable {
 	 */
 	public static function register(): void {
 		// Set SEO field types for product children.
-		$product_types = WP_GraphQL_WooCommerce::get_enabled_product_types();
+		$product_types = array_merge(
+			WP_GraphQL_WooCommerce::get_enabled_product_types(),
+			[
+				'ProductUnion',
+				'ProductWithPricing',
+				'ProductWithDimensions',
+				'InventoriedProduct',
+				'DownloadableProduct',
+				'ProductWithAttributes',
+				'ProductWithVariations',
+			]
+		);
 
 		foreach ( $product_types as $graphql_type_name ) {
 			Utils::overload_graphql_field_type( $graphql_type_name, 'seo', 'RankMathProductObjectSeo' );
 		}
 
-		// Register the Product Variation SEO type and apply it to the Product Variation and children.
-		$type_name_for_product_variation = 'RankMathProductVariationObjectSeo';
-
-		register_graphql_object_type(
-			$type_name_for_product_variation,
-			[
-				'description'     => __( 'The product variation object SEO data', 'wp-graphql-rank-math' ),
-				'interfaces'      => [ ContentNodeSeo::get_type_name() ],
-				'fields'          => [],
-				'eagerlyLoadType' => true,
-			]
-		);
-
-		$product_variations = array_merge(
-			[
-				'ProductVariation',
-			],
-			WP_GraphQL_WooCommerce::get_enabled_product_variation_types(),
-		);
-
-		foreach ( $product_variations as $product_variation ) {
-			Utils::overload_graphql_field_type( $product_variation, 'seo', $type_name_for_product_variation );
-		}
 	}
 }

--- a/src/Extensions/WPGraphQLWooCommerce/Type/WPObject/SeoObjects.php
+++ b/src/Extensions/WPGraphQLWooCommerce/Type/WPObject/SeoObjects.php
@@ -10,7 +10,6 @@ declare( strict_types = 1 );
 
 namespace WPGraphQL\RankMath\Extensions\WPGraphQLWooCommerce\Type\WPObject;
 
-use WPGraphQL\RankMath\Type\WPInterface\ContentNodeSeo;
 use WPGraphQL\RankMath\Utils\Utils;
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Interfaces\Registrable;
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Traits\TypeNameTrait;
@@ -50,6 +49,5 @@ class SeoObjects implements Registrable {
 		foreach ( $product_types as $graphql_type_name ) {
 			Utils::overload_graphql_field_type( $graphql_type_name, 'seo', 'RankMathProductObjectSeo' );
 		}
-
 	}
 }

--- a/src/Extensions/WPGraphQLWooCommerce/Type/WPObject/SeoObjects.php
+++ b/src/Extensions/WPGraphQLWooCommerce/Type/WPObject/SeoObjects.php
@@ -10,6 +10,7 @@ declare( strict_types = 1 );
 
 namespace WPGraphQL\RankMath\Extensions\WPGraphQLWooCommerce\Type\WPObject;
 
+use WPGraphQL\RankMath\Type\WPInterface\ContentNodeSeo;
 use WPGraphQL\RankMath\Utils\Utils;
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Interfaces\Registrable;
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Traits\TypeNameTrait;
@@ -33,21 +34,68 @@ class SeoObjects implements Registrable {
 	 */
 	public static function register(): void {
 		// Set SEO field types for product children.
-		$product_types = array_merge(
-			WP_GraphQL_WooCommerce::get_enabled_product_types(),
-			[
-				'ProductUnion',
-				'ProductWithPricing',
-				'ProductWithDimensions',
-				'InventoriedProduct',
-				'DownloadableProduct',
-				'ProductWithAttributes',
-				'ProductWithVariations',
-			]
-		);
+		$product_types = WP_GraphQL_WooCommerce::get_enabled_product_types();
+		/**
+		 * @todo: remove this when we don't need to support WooGraphQL< 0.21.1
+		 * @see https://github.com/AxeWP/wp-graphql-rank-math/pull/115#issuecomment-2660900767
+		 */
+		if ( defined( 'WPGRAPHQL_WOOCOMMERCE_VERSION' ) && version_compare( WPGRAPHQL_WOOCOMMERCE_VERSION, '0.21.1', '>=' ) ) {
+			$product_types = array_merge(
+				$product_types,
+				[
+					'ProductUnion',
+					'ProductWithPricing',
+					'ProductWithDimensions',
+					'InventoriedProduct',
+					'DownloadableProduct',
+					'ProductWithAttributes',
+					'ProductWithVariations',
+				]
+			);
+		}
 
 		foreach ( $product_types as $graphql_type_name ) {
 			Utils::overload_graphql_field_type( $graphql_type_name, 'seo', 'RankMathProductObjectSeo' );
+		}
+
+		/**
+		 * @todo: remove this when we don't need to support WooGraphQL< 0.21.1
+		 * @see https://github.com/AxeWP/wp-graphql-rank-math/pull/115#issuecomment-2660900767
+		 */
+		if ( defined( 'WPGRAPHQL_WOOCOMMERCE_VERSION' ) && version_compare( WPGRAPHQL_WOOCOMMERCE_VERSION, '0.21.1', '<' ) ) {
+			self::register_product_variation_types();
+		}
+	}
+
+	/**
+	 * Registers the SEO types for product variations.
+	 *
+	 * @todo: remove this when we don't need to support WooGraphQL< 0.21.1
+	 * @see https://github.com/AxeWP/wp-graphql-rank-math/pull/115#issuecomment-2660900767
+	 */
+	private static function register_product_variation_types(): void {
+		// Register the Product Variation SEO type and apply it to the Product Variation and children.
+		$type_name_for_product_variation = 'RankMathProductVariationObjectSeo';
+
+		register_graphql_object_type(
+			$type_name_for_product_variation,
+			[
+				'description'     => __( 'The product variation object SEO data', 'wp-graphql-rank-math' ),
+				'interfaces'      => [ ContentNodeSeo::get_type_name() ],
+				'fields'          => [],
+				'eagerlyLoadType' => true,
+			]
+		);
+
+		$product_variations = array_merge(
+			[
+				'ProductVariation',
+			],
+			WP_GraphQL_WooCommerce::get_enabled_product_variation_types(),
+		);
+
+		foreach ( $product_variations as $product_variation ) {
+			Utils::overload_graphql_field_type( $product_variation, 'seo', $type_name_for_product_variation );
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
Fixes the error on GraphQL IDE which cause by WooGraphQL [v0.21.1](https://github.com/wp-graphql/wp-graphql-woocommerce/releases/tag/v0.21.1)
## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
The GraphQL IDE becomes useless with this errors.
## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->
RankMathProductObjectSeo type for all WooGraphQL Product types which are in error message has been set.
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->
```
{
  "errors": [
    "Interface field Product.seo expects type RankMathProductObjectSeo but ProductVariation.seo is type RankMathProductVariationObjectSeo.",
    "Interface field Product.seo expects type RankMathProductObjectSeo but ProductUnion.seo is type RankMathSeo.",
    "Interface field ContentNode.seo expects type RankMathContentNodeSeo but ProductUnion.seo is type RankMathSeo.",
    "Interface field Product.seo expects type RankMathProductObjectSeo but ProductWithPricing.seo is type RankMathSeo.",
    "Interface field ContentNode.seo expects type RankMathContentNodeSeo but ProductWithPricing.seo is type RankMathSeo.",
    "Interface field Product.seo expects type RankMathProductObjectSeo but ProductWithDimensions.seo is type RankMathSeo.",
    "Interface field ContentNode.seo expects type RankMathContentNodeSeo but ProductWithDimensions.seo is type RankMathSeo.",
    "Interface field Product.seo expects type RankMathProductObjectSeo but InventoriedProduct.seo is type RankMathSeo.",
    "Interface field ContentNode.seo expects type RankMathContentNodeSeo but InventoriedProduct.seo is type RankMathSeo.",
    "Interface field Product.seo expects type RankMathProductObjectSeo but DownloadableProduct.seo is type RankMathSeo.",
    "Interface field ContentNode.seo expects type RankMathContentNodeSeo but DownloadableProduct.seo is type RankMathSeo.",
    "Interface field Product.seo expects type RankMathProductObjectSeo but ProductWithAttributes.seo is type RankMathSeo.",
    "Interface field ContentNode.seo expects type RankMathContentNodeSeo but ProductWithAttributes.seo is type RankMathSeo.",
    "Interface field Product.seo expects type RankMathProductObjectSeo but ProductWithVariations.seo is type RankMathSeo.",
    "Interface field ContentNode.seo expects type RankMathContentNodeSeo but ProductWithVariations.seo is type RankMathSeo.",
    "Interface field Product.seo expects type RankMathProductObjectSeo but SimpleProductVariation.seo is type RankMathProductVariationObjectSeo."
  ]
}
```
## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [] I have added unit tests to verify the code works as intended.
- [] The changes in this PR have been noted in CHANGELOG.md
