### PR TITLE
chore: bump PHPStan to v2.0.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- chore: bump PHPStan to v2.0.x
+
 ## [0.3.3]
 
 This _minor_ release adds a GraphQL Debug message to the response when attempting to use `Page.seo` for the Posts Archive. It also tests compatibility with WordPress 6.7.2 and WPGraphQL 2.0.0.

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
 		"axepress/wp-graphql-plugin-boilerplate": "^0.1.0"
 	},
 	"require-dev": {
-		"lucatume/wp-browser": "<3.5",
+		"axepress/wp-graphql-cs": "^2.0.0-beta",
+		"axepress/wp-graphql-stubs": "^2.0.0",
 		"codeception/lib-innerbrowser": "^1.0",
 		"codeception/module-asserts": "^1.0",
 		"codeception/module-cli": "^1.0",
@@ -42,16 +43,15 @@
 		"codeception/module-webdriver": "^1.0",
 		"codeception/phpunit-wrapper": "^9.0",
 		"codeception/util-universalframework": "^1.0",
-		"phpunit/phpunit": "^9.5",
-		"wp-graphql/wp-graphql-testcase": "~3.4.0",
-		"phpstan/phpstan": "^1.2",
-		"phpstan/extension-installer": "^1.1",
-		"szepeviktor/phpstan-wordpress": "^1.0",
-		"axepress/wp-graphql-stubs": "^1.22.1",
-		"axepress/wp-graphql-cs": "^2.0.0-beta",
+		"lucatume/wp-browser": "<3.5",
+		"php-coveralls/php-coveralls": "^2.5",
 		"phpcompatibility/php-compatibility": "dev-develop as 9.9.9",
+		"phpstan/extension-installer": "^1.1",
+		"phpstan/phpstan": "^2.1.5",
+		"phpunit/phpunit": "^9.5",
+		"szepeviktor/phpstan-wordpress": "^2.0.1",
 		"wp-cli/wp-cli-bundle": "^2.8.1",
-		"php-coveralls/php-coveralls": "^2.5"
+		"wp-graphql/wp-graphql-testcase": "~3.4.0"
 	},
 	"config": {
 		"allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f313a80706960ce78ece6b2fb096d6eb",
+    "content-hash": "4d9f306a136c74d800132250d6fa7caa",
     "packages": [
         {
             "name": "axepress/wp-graphql-plugin-boilerplate",
@@ -229,25 +229,25 @@
         },
         {
             "name": "axepress/wp-graphql-stubs",
-            "version": "v1.31.1",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/AxeWP/wp-graphql-stubs.git",
-                "reference": "55296773a7537e0dbc008010959718c7c796e170"
+                "reference": "46f4c2a007e4577a004f3a43a8fc2e02d305c7d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/AxeWP/wp-graphql-stubs/zipball/55296773a7537e0dbc008010959718c7c796e170",
-                "reference": "55296773a7537e0dbc008010959718c7c796e170",
+                "url": "https://api.github.com/repos/AxeWP/wp-graphql-stubs/zipball/46f4c2a007e4577a004f3a43a8fc2e02d305c7d4",
+                "reference": "46f4c2a007e4577a004f3a43a8fc2e02d305c7d4",
                 "shasum": ""
             },
             "require": {
-                "php-stubs/wordpress-stubs": "^5.4 || ^6.0"
+                "php-stubs/wordpress-stubs": ">=5.4"
             },
             "require-dev": {
-                "php": ">=7.3",
+                "php": ">=7.4",
                 "php-stubs/generator": "^0.8.0",
-                "phpstan/phpstan": "^1.8"
+                "phpstan/phpstan": "^2.1.5"
             },
             "suggest": {
                 "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
@@ -269,7 +269,7 @@
             ],
             "support": {
                 "issues": "https://github.com/AxeWP/wp-graphql-stubs/issues",
-                "source": "https://github.com/AxeWP/wp-graphql-stubs/tree/v1.31.1"
+                "source": "https://github.com/AxeWP/wp-graphql-stubs/tree/v2.0.0"
             },
             "funding": [
                 {
@@ -277,7 +277,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-29T12:41:14+00:00"
+            "time": "2025-02-15T14:48:32+00:00"
         },
         {
             "name": "behat/gherkin",
@@ -4391,20 +4391,20 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.18",
+            "version": "2.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "fef9f07814a573399229304bb0046affdf558812"
+                "reference": "451b17f9665481ee502adc39be987cb71067ece2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/fef9f07814a573399229304bb0046affdf558812",
-                "reference": "fef9f07814a573399229304bb0046affdf558812",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/451b17f9665481ee502adc39be987cb71067ece2",
+                "reference": "451b17f9665481ee502adc39be987cb71067ece2",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0"
+                "php": "^7.4|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -4445,7 +4445,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-13T12:44:44+00:00"
+            "time": "2025-02-13T12:49:56+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -8651,30 +8651,29 @@
         },
         {
             "name": "szepeviktor/phpstan-wordpress",
-            "version": "v1.3.5",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
-                "reference": "7f8cfe992faa96b6a33bbd75c7bace98864161e7"
+                "reference": "f7beb13cd22998e3d913fdb897a1e2553ccd637e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/7f8cfe992faa96b6a33bbd75c7bace98864161e7",
-                "reference": "7f8cfe992faa96b6a33bbd75c7bace98864161e7",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/f7beb13cd22998e3d913fdb897a1e2553ccd637e",
+                "reference": "f7beb13cd22998e3d913fdb897a1e2553ccd637e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0",
-                "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0",
-                "phpstan/phpstan": "^1.10.31",
-                "symfony/polyfill-php73": "^1.12.0"
+                "php": "^7.4 || ^8.0",
+                "php-stubs/wordpress-stubs": "^6.6.2",
+                "phpstan/phpstan": "^2.0"
             },
             "require-dev": {
                 "composer/composer": "^2.1.14",
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "php-parallel-lint/php-parallel-lint": "^1.1",
-                "phpstan/phpstan-strict-rules": "^1.2",
-                "phpunit/phpunit": "^8.0 || ^9.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.0",
                 "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.0",
                 "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
             },
@@ -8708,9 +8707,9 @@
             ],
             "support": {
                 "issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
-                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v1.3.5"
+                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v2.0.1"
             },
-            "time": "2024-06-28T22:27:19+00:00"
+            "time": "2024-12-01T02:13:05+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,21 +2,17 @@ parameters:
 		level: 8
 		treatPhpDocTypesAsCertain: false
 		inferPrivatePropertyTypeFromConstructor: true
-		checkAlwaysTrueCheckTypeFunctionCall: true
-		checkAlwaysTrueInstanceof: true
-		checkAlwaysTrueStrictComparison: true
 		checkExplicitMixedMissingReturn: true
 		checkFunctionNameCase: true
 		checkInternalClassCaseSensitivity: true
-		checkMissingIterableValueType: true
 		checkTooWideReturnTypesInProtectedAndPublicMethods: true
 		polluteScopeWithAlwaysIterableForeach: false
 		polluteScopeWithLoopInitialAssignments: false
 		reportAlwaysTrueInLastCondition: true
 		reportStaticMethodSignatures: true
 		reportWrongPhpDocTypeInVarTag: true
-		featureToggles:
-			disableRuntimeReflectionProvider: true
+		bootstrapFiles:
+			- phpstan/constants.php
 		dynamicConstantNames:
 			- WPGRAPHQL_SEO_AUTOLOAD
 		stubFiles:
@@ -24,13 +20,12 @@ parameters:
 			- phpstan/rank-math.stub
 			- phpstan/class-breadcrumbs.stub
 			- phpstan/class-choices.stub
-			- phpstan/class-singular.stub
+			- phpstan/class-database.stub
 			- phpstan/class-helpers.stub
+			- phpstan/class-singular.stub
 			- vendor/axepress/wp-graphql-plugin-boilerplate/phpstan/class-wp-post-type.stub
 			- vendor/axepress/wp-graphql-plugin-boilerplate/phpstan/class-wp-taxonomy.stub
 			- vendor/axepress/wp-graphql-plugin-boilerplate/phpstan/Model.stub
-		bootstrapFiles:
-			- phpstan/constants.php
 		paths:
 			- wp-graphql-rank-math.php
 			- access-functions.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,12 +17,13 @@ parameters:
 			- WPGRAPHQL_SEO_AUTOLOAD
 		stubFiles:
 			# Simulate added properties
-			- phpstan/rank-math.stub
 			- phpstan/class-breadcrumbs.stub
 			- phpstan/class-choices.stub
 			- phpstan/class-database.stub
 			- phpstan/class-helpers.stub
 			- phpstan/class-singular.stub
+			- phpstan/namespace-rank-math.stub
+			- phpstan/rank-math.stub
 			- vendor/axepress/wp-graphql-plugin-boilerplate/phpstan/class-wp-post-type.stub
 			- vendor/axepress/wp-graphql-plugin-boilerplate/phpstan/class-wp-taxonomy.stub
 			- vendor/axepress/wp-graphql-plugin-boilerplate/phpstan/Model.stub

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -34,10 +34,11 @@ parameters:
 			- src/
 		excludePaths:
 			analyse:
-				- vendor-prefixed
+				- vendor-prefixed/
 		scanFiles:
 			- vendor/axepress/wp-graphql-stubs/wp-graphql-stubs.php
 		scanDirectories:
-			- ../seo-by-rank-math
-			- ../wp-graphql-woocommerce
+			- ../seo-by-rank-math/
+			- ../seo-by-rank-math/includes/
+			- ../wp-graphql-woocommerce/includes/
 			- vendor-prefixed/axepress/wp-graphql-plugin-boilerplate/src/

--- a/phpstan/class-database.stub
+++ b/phpstan/class-database.stub
@@ -1,0 +1,25 @@
+<?php
+/**
+ * The Database.
+ *
+ * @since      1.0.0
+ * @package    MyThemeShop
+ * @subpackage MyThemeShop\Database
+ * @author     MyThemeShop <admin@mythemeshop.com>
+ */
+
+namespace MyThemeShop\Database;
+
+/**
+ * Database class.
+ */
+class Database {
+	/**
+	 * Retrieve a Database instance by table name.
+	 *
+	 * @param string $table_name A Database instance id.
+	 *
+	 * @return \RankMath\Admin\Database\Query_Builder
+	 */
+	public static function table( $table_name ) {}
+}

--- a/phpstan/class-database.stub
+++ b/phpstan/class-database.stub
@@ -19,7 +19,12 @@ class Database {
 	 *
 	 * @param string $table_name A Database instance id.
 	 *
-	 * @return \RankMath\Admin\Database\Query_Builder
+	 * @return \MyThemeShop\Database\Query_Builder
 	 */
 	public static function table( $table_name ) {}
 }
+
+/**
+ * Query_Builder class.
+ */
+class Query_Builder {}

--- a/phpstan/namespace-rank-math.stub
+++ b/phpstan/namespace-rank-math.stub
@@ -1,0 +1,16 @@
+<?php
+
+namespace RankMath;
+
+class Frontend_SEO_Score {}
+
+class Settings {}
+
+namespace RankMath\Replace_Variables;
+
+class Manager {}
+
+namespace RankMath\Module;
+
+class Manager {}
+

--- a/src/Modules/Redirection/Connection/RedirectionConnection.php
+++ b/src/Modules/Redirection/Connection/RedirectionConnection.php
@@ -32,7 +32,6 @@ class RedirectionConnection extends ConnectionType {
 	 * {@inheritDoc}
 	 */
 	public static function register(): void {
-		/** @var array<string,mixed> $config */
 		$config = self::get_connection_config(
 			[
 				'fromType'       => 'RootQuery',

--- a/src/Modules/Redirection/Model/Redirection.php
+++ b/src/Modules/Redirection/Model/Redirection.php
@@ -16,19 +16,19 @@ use WPGraphQL\RankMath\Utils\RMUtils;
 /**
  * Class - Redirection
  *
- * @property ?int $databaseId The redirection database ID.
- * @property ?string $dateCreated The date the redirection was created.
+ * @property ?int                 $databaseId The redirection database ID.
+ * @property ?string              $dateCreated The date the redirection was created.
  * @property ?string $dateCreatedGmt The GMT date the redirection was created.
- * @property ?string $dateModified The date the redirection was last modified.
- * @property ?string $dateModifiedGmt The GMT date the redirection was last modified.
- * @property ?string $dateLastAccessed The date the redirection was last accessed.
- * @property ?string $dateLastAccessedGmt The GMT date the redirection was last accessed.
- * @property ?int $hits The number of hits for this redirection.
- * @property string $id The global ID of the redirection.
- * @property ?string $redirectToUrl The URL to redirect to.
- * @property ?array $sources The sources for this redirection.
- * @property ?string $status The status of the redirection.
- * @property ?int $type The type of redirection.
+ * @property ?string              $dateModified The date the redirection was last modified.
+ * @property ?string              $dateModifiedGmt The GMT date the redirection was last modified.
+ * @property ?string              $dateLastAccessed The date the redirection was last accessed.
+ * @property ?string              $dateLastAccessedGmt The GMT date the redirection was last accessed.
+ * @property ?int                 $hits The number of hits for this redirection.
+ * @property string               $id The global ID of the redirection.
+ * @property ?string              $redirectToUrl The URL to redirect to.
+ * @property ?array<string,mixed> $sources The sources for this redirection.
+ * @property ?string              $status The status of the redirection.
+ * @property ?int                 $type The type of redirection.
  */
 class Redirection extends Model {
 	/**

--- a/src/Utils/RMUtils.php
+++ b/src/Utils/RMUtils.php
@@ -51,7 +51,7 @@ class RMUtils {
 	 *
 	 * @since 0.0.13
 	 *
-	 * @return \RankMath\Admin\Database\Query_Builder
+	 * @return \MyThemeShop\Database\Query_Builder
 	 */
 	public static function get_redirections_table() {
 		return Database::table( 'rank_math_redirections' );

--- a/src/Utils/RMUtils.php
+++ b/src/Utils/RMUtils.php
@@ -51,14 +51,9 @@ class RMUtils {
 	 *
 	 * @since 0.0.13
 	 *
-	 * @return \MyThemeShop\Database\Query_Builder
+	 * @return \RankMath\Admin\Database\Query_Builder
 	 */
 	public static function get_redirections_table() {
-		/**
-		 * Query_Builder gives us the methods we need to interact with.
-		 *
-		 * @var \MyThemeShop\Database\Query_Builder
-		 */
 		return Database::table( 'rank_math_redirections' );
 	}
 

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'axepress/wp-graphql-rank-math',
         'pretty_version' => 'dev-develop',
         'version' => 'dev-develop',
-        'reference' => '1cf41e140fb2c8b810cdb4dc93f6befec9bf482a',
+        'reference' => '477ff13f315f9e172c0aa84a84e0a37aace06ab1',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -22,7 +22,7 @@
         'axepress/wp-graphql-rank-math' => array(
             'pretty_version' => 'dev-develop',
             'version' => 'dev-develop',
-            'reference' => '1cf41e140fb2c8b810cdb4dc93f6befec9bf482a',
+            'reference' => '477ff13f315f9e172c0aa84a84e0a37aace06ab1',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'axepress/wp-graphql-rank-math',
         'pretty_version' => 'dev-develop',
         'version' => 'dev-develop',
-        'reference' => '477ff13f315f9e172c0aa84a84e0a37aace06ab1',
+        'reference' => '191148867d74f25ed7ae2ffd3fef88dd8c1f77a1',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -22,7 +22,7 @@
         'axepress/wp-graphql-rank-math' => array(
             'pretty_version' => 'dev-develop',
             'version' => 'dev-develop',
-            'reference' => '477ff13f315f9e172c0aa84a84e0a37aace06ab1',
+            'reference' => '191148867d74f25ed7ae2ffd3fef88dd8c1f77a1',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

Bumps PHPStan to v2.0.0 alongside updates to `wp-graphql-stubs` and related deps.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md
