### PR TITLE
fix: interface conflicts with WooGraphQL v0.21.1+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- fix: Fix type conflicts on Product interfaces in WooGraphQL 0.21.1+. Props @robbiebel 🙌
 - chore: bump PHPStan to v2.0.x
 - chore: Test compatibility with WordPress 6.8 and WPGraphQL 2.3.
 - chore: Update Composer dev-dependencies and lint.

--- a/bin/_lib.sh
+++ b/bin/_lib.sh
@@ -98,11 +98,19 @@ install_woographql() {
 
 	echo "Installing WooCommerce..."
 	if ! $(wp plugin is-installed woocommerce); then
-		wp plugin install woocommerce --activate
+		wp plugin install woocommerce --activate --allow-root
 	fi
 
 	if ! $(wp plugin is-installed wp-graphql-woocommerce); then
-		wp plugin install https://github.com/wp-graphql/wp-graphql-woocommerce/releases/download/v0.21.0/wp-graphql-woocommerce.zip --activate
+		wp plugin install https://github.com/wp-graphql/wp-graphql-woocommerce/archive/refs/heads/master.zip --allow-root
+		cd $WP_CORE_DIR/wp-content/plugins/wp-graphql-woocommerce
+
+		if [ ! -d vendor ]; then
+			composer install --no-dev
+		fi
+
+		wp plugin activate wp-graphql-woocommerce --allow-root
+
 	fi
 }
 

--- a/src/Extensions/WPGraphQLWooCommerce/Type/WPObject/SeoObjects.php
+++ b/src/Extensions/WPGraphQLWooCommerce/Type/WPObject/SeoObjects.php
@@ -34,34 +34,22 @@ class SeoObjects implements Registrable {
 	 */
 	public static function register(): void {
 		// Set SEO field types for product children.
-		$product_types = WP_GraphQL_WooCommerce::get_enabled_product_types();
+		$product_types = array_merge(
+			WP_GraphQL_WooCommerce::get_enabled_product_types(),
+			[
+				'ProductUnion',
+				'ProductWithPricing',
+				'ProductWithDimensions',
+				'InventoriedProduct',
+				'DownloadableProduct',
+				'ProductWithAttributes',
+				'ProductWithVariations',
+			]
+		);
 
 		foreach ( $product_types as $graphql_type_name ) {
 			Utils::overload_graphql_field_type( $graphql_type_name, 'seo', 'RankMathProductObjectSeo' );
 		}
 
-		// Register the Product Variation SEO type and apply it to the Product Variation and children.
-		$type_name_for_product_variation = 'RankMathProductVariationObjectSeo';
-
-		register_graphql_object_type(
-			$type_name_for_product_variation,
-			[
-				'description'     => __( 'The product variation object SEO data', 'wp-graphql-rank-math' ),
-				'interfaces'      => [ ContentNodeSeo::get_type_name() ],
-				'fields'          => [],
-				'eagerlyLoadType' => true,
-			]
-		);
-
-		$product_variations = array_merge(
-			[
-				'ProductVariation',
-			],
-			WP_GraphQL_WooCommerce::get_enabled_product_variation_types(),
-		);
-
-		foreach ( $product_variations as $product_variation ) {
-			Utils::overload_graphql_field_type( $product_variation, 'seo', $type_name_for_product_variation );
-		}
 	}
 }

--- a/src/Extensions/WPGraphQLWooCommerce/Type/WPObject/SeoObjects.php
+++ b/src/Extensions/WPGraphQLWooCommerce/Type/WPObject/SeoObjects.php
@@ -10,7 +10,6 @@ declare( strict_types = 1 );
 
 namespace WPGraphQL\RankMath\Extensions\WPGraphQLWooCommerce\Type\WPObject;
 
-use WPGraphQL\RankMath\Type\WPInterface\ContentNodeSeo;
 use WPGraphQL\RankMath\Utils\Utils;
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Interfaces\Registrable;
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Traits\TypeNameTrait;
@@ -50,6 +49,5 @@ class SeoObjects implements Registrable {
 		foreach ( $product_types as $graphql_type_name ) {
 			Utils::overload_graphql_field_type( $graphql_type_name, 'seo', 'RankMathProductObjectSeo' );
 		}
-
 	}
 }

--- a/src/Extensions/WPGraphQLWooCommerce/Type/WPObject/SeoObjects.php
+++ b/src/Extensions/WPGraphQLWooCommerce/Type/WPObject/SeoObjects.php
@@ -10,6 +10,7 @@ declare( strict_types = 1 );
 
 namespace WPGraphQL\RankMath\Extensions\WPGraphQLWooCommerce\Type\WPObject;
 
+use WPGraphQL\RankMath\Type\WPInterface\ContentNodeSeo;
 use WPGraphQL\RankMath\Utils\Utils;
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Interfaces\Registrable;
 use WPGraphQL\RankMath\Vendor\AxeWP\GraphQL\Traits\TypeNameTrait;
@@ -33,21 +34,68 @@ class SeoObjects implements Registrable {
 	 */
 	public static function register(): void {
 		// Set SEO field types for product children.
-		$product_types = array_merge(
-			WP_GraphQL_WooCommerce::get_enabled_product_types(),
-			[
-				'ProductUnion',
-				'ProductWithPricing',
-				'ProductWithDimensions',
-				'InventoriedProduct',
-				'DownloadableProduct',
-				'ProductWithAttributes',
-				'ProductWithVariations',
-			]
-		);
+		$product_types = WP_GraphQL_WooCommerce::get_enabled_product_types();
+		/**
+		 * @todo: remove this when we don't need to support WooGraphQL< 0.21.1
+		 * @see https://github.com/AxeWP/wp-graphql-rank-math/pull/115#issuecomment-2660900767
+		 */
+		if ( defined( 'WPGRAPHQL_WOOCOMMERCE_VERSION' ) && version_compare( WPGRAPHQL_WOOCOMMERCE_VERSION, '0.21.1', '>=' ) ) {
+			$product_types = array_merge(
+				$product_types,
+				[
+					'ProductUnion',
+					'ProductWithPricing',
+					'ProductWithDimensions',
+					'InventoriedProduct',
+					'DownloadableProduct',
+					'ProductWithAttributes',
+					'ProductWithVariations',
+				]
+			);
+		}
 
 		foreach ( $product_types as $graphql_type_name ) {
 			Utils::overload_graphql_field_type( $graphql_type_name, 'seo', 'RankMathProductObjectSeo' );
+		}
+
+		/**
+		 * @todo: remove this when we don't need to support WooGraphQL< 0.21.1
+		 * @see https://github.com/AxeWP/wp-graphql-rank-math/pull/115#issuecomment-2660900767
+		 */
+		if ( defined( 'WPGRAPHQL_WOOCOMMERCE_VERSION' ) && version_compare( WPGRAPHQL_WOOCOMMERCE_VERSION, '0.21.1', '<' ) ) {
+			self::register_product_variation_types();
+		}
+	}
+
+	/**
+	 * Registers the SEO types for product variations.
+	 *
+	 * @todo: remove this when we don't need to support WooGraphQL< 0.21.1
+	 * @see https://github.com/AxeWP/wp-graphql-rank-math/pull/115#issuecomment-2660900767
+	 */
+	private static function register_product_variation_types(): void {
+		// Register the Product Variation SEO type and apply it to the Product Variation and children.
+		$type_name_for_product_variation = 'RankMathProductVariationObjectSeo';
+
+		register_graphql_object_type(
+			$type_name_for_product_variation,
+			[
+				'description'     => __( 'The product variation object SEO data', 'wp-graphql-rank-math' ),
+				'interfaces'      => [ ContentNodeSeo::get_type_name() ],
+				'fields'          => [],
+				'eagerlyLoadType' => true,
+			]
+		);
+
+		$product_variations = array_merge(
+			[
+				'ProductVariation',
+			],
+			WP_GraphQL_WooCommerce::get_enabled_product_variation_types(),
+		);
+
+		foreach ( $product_variations as $product_variation ) {
+			Utils::overload_graphql_field_type( $product_variation, 'seo', $type_name_for_product_variation );
 		}
 	}
 }

--- a/src/Extensions/WPGraphQLWooCommerce/Type/WPObject/SeoObjects.php
+++ b/src/Extensions/WPGraphQLWooCommerce/Type/WPObject/SeoObjects.php
@@ -43,13 +43,14 @@ class SeoObjects implements Registrable {
 			$product_types = array_merge(
 				$product_types,
 				[
-					'ProductUnion',
-					'ProductWithPricing',
-					'ProductWithDimensions',
-					'InventoriedProduct',
 					'DownloadableProduct',
+					'InventoriedProduct',
+					'ProductUnion',
 					'ProductWithAttributes',
+					'ProductWithDimensions',
+					'ProductWithPricing',
 					'ProductWithVariations',
+					'ProductVariation',
 				]
 			);
 		}


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR fixes issues caused by WooGraphQL v0.21.1.

Based on #115 by @robbiebel but with CI that hasn't been autodisabled by github.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

- The bug is a side effect of the tech debt mentioned in https://github.com/AxeWP/wp-graphql-rank-math/issues/99#issuecomment-2281487503
-  https://github.com/wp-graphql/wp-graphql-woocommerce/pull/901 decided to make `ProductVariation` a child of `Product` (by way of ProductUnion ). I'm not sure if this is a bug or not, but I'll be following up with @kidunot89
- bug in WooGraphQL or no, https://github.com/wp-graphql/wp-graphql/issues/3096 would make sure things don't break downstream.

https://github.com/AxeWP/wp-graphql-rank-math/pull/115#issuecomment-2660900767

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md
